### PR TITLE
Client and server binary targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 ]
 
 [workspace.dependencies]
+hearth-network = { path = "crates/hearth-network" }
 hearth-rpc = { path = "crates/hearth-rpc" }
 hearth-types = { path = "crates/hearth-types" }
 hearth-wasm = { path = "crates/hearth-wasm" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "crates/font-mud",
+  "crates/hearth-client",
   "crates/hearth-cognito",
   "crates/hearth-core",
   "crates/hearth-guest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "crates/hearth-guest",
   "crates/hearth-network",
   "crates/hearth-rpc",
+  "crates/hearth-server",
   "crates/hearth-types",
   "crates/hearth-wasm",
 ]

--- a/crates/hearth-client/Cargo.toml
+++ b/crates/hearth-client/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 clap = { version= "4", features = ["derive"] }
 hearth-network = { workspace = true }
 hearth-rpc = { workspace = true }
+remoc = { workspace = true, features = ["full"] }
 tokio = { version = "1.24", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["fmt"] }

--- a/crates/hearth-client/Cargo.toml
+++ b/crates/hearth-client/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "hearth-client"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version= "4", features = ["derive"] }
+hearth-network = { workspace = true }
+hearth-rpc = { workspace = true }
+tokio = { version = "1.24", features = ["full"] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", features = ["fmt"] }

--- a/crates/hearth-client/src/main.rs
+++ b/crates/hearth-client/src/main.rs
@@ -1,0 +1,47 @@
+use std::net::SocketAddr;
+
+use clap::Parser;
+use hearth_network::auth::login;
+use tokio::net::TcpStream;
+use tracing::{debug, info, error};
+
+/// Client program to the Hearth virtual space server.
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// IP address and port of the server to connect to.
+    // TODO support DNS resolution too
+    #[arg(short, long)]
+    pub server: SocketAddr,
+
+    /// Password to use to authenticate to the server. Defaults to empty.
+    #[arg(short, long, default_value = "")]
+    pub password: String,
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+
+    let format = tracing_subscriber::fmt::format().compact();
+    tracing_subscriber::fmt().event_format(format).init();
+
+    info!("Connecting to server at {:?}...", args.server);
+    let mut socket = match TcpStream::connect(args.server).await {
+        Ok(s) => s,
+        Err(err) => {
+            error!("Failed to connect to server: {:?}", err);
+            return;
+        }
+    };
+
+    info!("Authenticating...");
+    let key = match login(&mut socket, args.password.as_bytes()).await {
+        Ok(key) => key,
+        Err(err) => {
+            error!("Failed to authenticate with server: {:?}", err);
+            return;
+        }
+    };
+
+    info!("Successfully connected!");
+}

--- a/crates/hearth-server/Cargo.toml
+++ b/crates/hearth-server/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "hearth-server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+hearth-network = { workspace = true }
+hearth-rpc = { workspace = true }
+tokio = { version = "1.24", features = ["full"] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", features = ["fmt"] }

--- a/crates/hearth-server/Cargo.toml
+++ b/crates/hearth-server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 clap = { version = "4", features = ["derive"] }
 hearth-network = { workspace = true }
 hearth-rpc = { workspace = true }
+remoc = { workspace = true, features = ["full"] }
 tokio = { version = "1.24", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["fmt"] }

--- a/crates/hearth-server/src/main.rs
+++ b/crates/hearth-server/src/main.rs
@@ -1,0 +1,73 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use clap::Parser;
+use hearth_network::auth::ServerAuthenticator;
+use tokio::net::{TcpListener, TcpStream};
+use tracing::{error, info};
+
+/// The Hearth virtual space server program.
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// IP address and port to listen on.
+    #[arg(short, long)]
+    pub bind: SocketAddr,
+
+    /// Password to use to authenticate with clients. Defaults to empty.
+    #[arg(short, long, default_value = "")]
+    pub password: String,
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+
+    let format = tracing_subscriber::fmt::format().compact();
+    tracing_subscriber::fmt().event_format(format).init();
+
+    let authenticator = ServerAuthenticator::from_password(args.password.as_bytes()).unwrap();
+    let authenticator = Arc::new(authenticator);
+
+    info!("Binding to {:?}...", args.bind);
+    let listener = match TcpListener::bind(args.bind).await {
+        Ok(l) => l,
+        Err(err) => {
+            error!("Failed to listen: {:?}", err);
+            return;
+        }
+    };
+
+    info!("Listening");
+    loop {
+        let (socket, addr) = match listener.accept().await {
+            Ok(v) => v,
+            Err(err) => {
+                error!("Listening error: {:?}", err);
+                continue;
+            }
+        };
+
+        info!("Connection from {:?}", addr);
+        let authenticator = authenticator.clone();
+        tokio::task::spawn(async move {
+            on_accept(authenticator, socket, addr).await;
+        });
+    }
+}
+
+async fn on_accept(
+    authenticator: Arc<ServerAuthenticator>,
+    mut client: TcpStream,
+    addr: SocketAddr,
+) {
+    info!("Authenticating with client {:?}...", addr);
+    let session_key = match authenticator.login(&mut client).await {
+        Ok(key) => key,
+        Err(err) => {
+            error!("Authentication error: {:?}", err);
+            return;
+        }
+    };
+
+    info!("Successfully authenticated");
+}

--- a/crates/hearth-server/src/main.rs
+++ b/crates/hearth-server/src/main.rs
@@ -3,6 +3,11 @@ use std::sync::Arc;
 
 use clap::Parser;
 use hearth_network::auth::ServerAuthenticator;
+use hearth_rpc::{
+    CallResult, ClientApiProvider, ClientApiProviderClient, ClientApiProviderServerShared,
+    ProcessApiClient,
+};
+use remoc::rtc::{async_trait, ServerShared};
 use tokio::net::{TcpListener, TcpStream};
 use tracing::{error, info};
 
@@ -70,4 +75,43 @@ async fn on_accept(
     };
 
     info!("Successfully authenticated");
+    use hearth_network::encryption::{AsyncDecryptor, AsyncEncryptor, Key};
+    let client_key = Key::from_client_session(&session_key);
+    let server_key = Key::from_server_session(&session_key);
+
+    let (client_rx, client_tx) = tokio::io::split(client);
+    let client_rx = AsyncDecryptor::new(&client_key, client_rx);
+    let client_tx = AsyncEncryptor::new(&server_key, client_tx);
+
+    use remoc::rch::base::{Receiver, Sender};
+    let cfg = remoc::Cfg::default();
+    let (conn, mut tx, _rx): (_, Sender<ClientApiProviderClient>, Receiver<()>) =
+        match remoc::Connect::io(cfg, client_rx, client_tx).await {
+            Ok(v) => v,
+            Err(err) => {
+                error!("Remoc connection failure: {:?}", err);
+                return;
+            }
+        };
+
+    tokio::spawn(conn);
+
+    let server = ClientApiProviderImpl;
+    let server = std::sync::Arc::new(server);
+    let (provider, provider_client) =
+        ClientApiProviderServerShared::<_, remoc::codec::Default>::new(server, 1024);
+    tokio::spawn(async move {
+        provider.serve(true).await;
+    });
+    tx.send(provider_client).await.unwrap();
+}
+
+struct ClientApiProviderImpl;
+
+#[async_trait]
+impl ClientApiProvider for ClientApiProviderImpl {
+    async fn get_process_api(&self) -> CallResult<ProcessApiClient> {
+        error!("ClientApiProviderImpl::get_process_api() is unimplemented");
+        Err(remoc::rtc::CallError::Dropped)
+    }
 }


### PR DESCRIPTION
I added `hearth-client` and `hearth-server` crates with `tracing` logging, `clap` command line parameters, password authentication and encryption from `hearth-network`, and exchange of a `ClientApiClient` from the server to the client over Remoc.