### PR TITLE
rpc: Peer-based API

### DIFF
--- a/crates/hearth-client/src/main.rs
+++ b/crates/hearth-client/src/main.rs
@@ -24,7 +24,10 @@ async fn main() {
     let args = Args::parse();
 
     let format = tracing_subscriber::fmt::format().compact();
-    tracing_subscriber::fmt().event_format(format).init();
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .event_format(format)
+        .init();
 
     info!("Connecting to server at {:?}...", args.server);
     let mut socket = match TcpStream::connect(args.server).await {

--- a/crates/hearth-cognito/Cargo.toml
+++ b/crates/hearth-cognito/Cargo.toml
@@ -3,9 +3,9 @@ name = "hearth-cognito"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-wasmtime = "5.0.0"
-hearth-rpc = { workspace = true }
 hearth-wasm = { workspace = true }
+wasmtime = "5.0.0"
+
+[dev-dependencies]
+tokio = { version = "1.24", features = ["macros", "rt"] }

--- a/crates/hearth-cognito/src/lib.rs
+++ b/crates/hearth-cognito/src/lib.rs
@@ -1,18 +1,15 @@
-use hearth_rpc::ProcessApi;
 use hearth_wasm::{GuestMemory, WasmLinker};
 use wasmtime::{Caller, Linker};
 
 /// This contains all script-accessible process-related stuff.
-pub struct Cognito {
-    pub api: Box<dyn ProcessApi + Send + Sync>,
-}
+pub struct Cognito {}
 
 // Should automatically generate link_print_hello_world:
 // #[impl_wasm_linker]
 // should work for any struct, not just Cognito
 impl Cognito {
     pub async fn print_hello_world(&self) {
-        self.api.print_hello_world().await.unwrap();
+        eprintln!("Hello, world!");
     }
 
     // impl_wasm_linker should also work with non-async functions
@@ -77,46 +74,9 @@ impl<T: AsRef<Cognito> + Send + 'static> WasmLinker<T> for Cognito {
 mod tests {
     use super::*;
 
-    use hearth_rpc::hearth_types::*;
-    use hearth_rpc::{remoc, CallResult};
-    use remoc::rtc::async_trait;
-
-    struct MockProcessApi;
-
-    #[async_trait]
-    #[allow(unused)]
-    impl ProcessApi for MockProcessApi {
-        async fn print_hello_world(&self) -> CallResult<()> {
-            println!("Hello, world!");
-            Ok(())
-        }
-
-        async fn spawn(
-            &self,
-            module: AssetId,
-            peer: PeerId,
-            linked: bool,
-        ) -> CallResult<ProcessId> {
-            unimplemented!()
-        }
-
-        async fn link(&self, pid: ProcessId) -> CallResult<()> {
-            unimplemented!()
-        }
-
-        async fn unlink(&self, pid: ProcessId) -> CallResult<()> {
-            unimplemented!()
-        }
-
-        async fn kill(&self, pid: ProcessId) -> CallResult<()> {
-            unimplemented!()
-        }
-    }
-
-    #[test]
-    fn host_works() {
-        let api = Box::new(MockProcessApi);
-        let cognito = Cognito { api };
-        cognito.print_hello_world();
+    #[tokio::test]
+    async fn host_works() {
+        let cognito = Cognito {};
+        cognito.print_hello_world().await;
     }
 }

--- a/crates/hearth-rpc/src/lib.rs
+++ b/crates/hearth-rpc/src/lib.rs
@@ -1,13 +1,44 @@
 use hearth_types::*;
 
+use remoc::robs::hash_map::HashMapSubscription;
+use remoc::robs::list::ListSubscription;
 use remoc::rtc::{remote, CallError};
+use serde::{Deserialize, Serialize};
 
-pub use remoc;
 pub use hearth_types;
+pub use remoc;
 
 pub type CallResult<T> = Result<T, CallError>;
 
-/// An interface for acquiring access to a client's remote APIs.
+/// An interface for acquiring access to the other peers on the network.
+#[remote]
+pub trait PeerProvider {
+    /// Retrieves the [PeerApi] of a peer by its ID, if there is a peer with that ID.
+    async fn find_peer(&self, id: PeerId) -> CallResult<Option<PeerApiClient>>;
+
+    /// Subscribes to the list of peers in the space.
+    async fn follow_peer_list(&self) -> CallResult<HashMapSubscription<PeerId, PeerInfo>>;
+}
+
+/// The initial data sent from server to client when a client connects.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ServerOffer {
+    /// A remote [PeerProvider] for accessing the rest of the peers on the network.
+    pub peer_provider: PeerProviderClient,
+
+    /// The new [PeerId] for this client.
+    pub new_id: PeerId,
+}
+
+/// The initial data sent from server to client after a client receives [ServerOffer].
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ClientOffer {
+    /// The remote [PeerApi] of this client.
+    pub peer_api: PeerApiClient,
+}
+
+/// Top-level interface for a peer. Provides access to its metadata as well as
+/// its lower-level interfaces.
 ///
 /// This is an example of the [Service Locator design pattern](https://gameprogrammingpatterns.com/service-locator.html).
 /// This is considered an anti-pattern by some because services acquired
@@ -16,16 +47,88 @@ pub type CallResult<T> = Result<T, CallError>;
 /// implementations to the real remote implementation, which could be made
 /// testable with mocks at no consequence on this interface.
 #[remote]
-pub trait ClientApiProvider {
-    async fn get_process_api(&self) -> CallResult<ProcessApiClient>;
+pub trait PeerApi {
+    /// Gets this peer's metadata.
+    async fn get_info(&self) -> CallResult<PeerInfo>;
+
+    /// Gets this peer's process store.
+    async fn get_process_store(&self) -> CallResult<ProcessStoreClient>;
 }
 
+/// A peer's metadata.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PeerInfo {
+    /// This peer's nickname, if it has one.
+    pub nickname: Option<String>,
+}
+
+/// Interface to a peer's process store. This is where all the magic happens.
+///
+/// Note that all process IDs (PIDs) are *local* PIDs, not global PIDs, because
+/// this store belongs to a specific peer.
 #[remote]
-pub trait ProcessApi {
+pub trait ProcessStore {
+    /// Placeholder function call for testing.
     async fn print_hello_world(&self) -> CallResult<()>;
-    async fn spawn(&self, module: AssetId, peer: PeerId, linked: bool) -> CallResult<ProcessId>;
-    async fn link(&self, pid: ProcessId) -> CallResult<()>; // TODO watcher channel for child errors?
-    async fn unlink(&self, pid: ProcessId) -> CallResult<()>;
-    async fn kill(&self, pid: ProcessId) -> CallResult<()>;
+
+    /// Spawns a new process.
+    async fn spawn(&self, module: LumpId) -> CallResult<LocalProcessId>;
+
+    /// Kills a process.
+    async fn kill(&self, pid: LocalProcessId) -> CallResult<()>;
+
+    /// Registers a process as a named service.
+    ///
+    /// Returns `Ok(true)` if the process was successfully registered or
+    /// `Ok(false)` if the service name is taken.
+    async fn register_service(&self, pid: LocalProcessId, name: String) -> CallResult<bool>;
+
+    /// Deregisters a service.
+    async fn deregister_service(&self, name: String) -> CallResult<()>;
+
+    /// Subscribes to a process's log.
+    async fn follow_process_log(
+        &self,
+        pid: LocalProcessId,
+    ) -> CallResult<ListSubscription<ProcessLogEvent>>;
+
+    /// Subscribes to this store's process list.
+    ///
+    /// This list is updated live as processes are spawned, killed, or changed.
+    async fn follow_process_list(
+        &self,
+    ) -> CallResult<HashMapSubscription<LocalProcessId, ProcessInfo>>;
+
+    /// Subscribes to this store's service list.
+    ///
+    /// This list is updated live as services are registered and deregistered.
+    async fn follow_service_list(&self) -> CallResult<HashMapSubscription<String, LocalProcessId>>;
+
     // TODO Lunatic Supervisor-like child API?
+}
+
+/// Log event emitted by a process.
+#[derive(Clone, Debug, Hash, Deserialize, Serialize)]
+pub struct ProcessLogEvent {
+    pub level: ProcessLogLevel,
+    pub module: String,
+    pub content: String,
+    // TODO optional source code location?
+    // TODO serializeable timestamp?
+}
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Deserialize, Serialize)]
+pub enum ProcessLogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warning,
+    Error,
+}
+
+/// A process's metadata.
+#[derive(Clone, Debug, Hash, Deserialize, Serialize)]
+pub struct ProcessInfo {
+    /// The [LumpId] of this process's source.
+    pub source_lump: LumpId,
 }

--- a/crates/hearth-server/src/main.rs
+++ b/crates/hearth-server/src/main.rs
@@ -28,7 +28,10 @@ async fn main() {
     let args = Args::parse();
 
     let format = tracing_subscriber::fmt::format().compact();
-    tracing_subscriber::fmt().event_format(format).init();
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .event_format(format)
+        .init();
 
     let authenticator = ServerAuthenticator::from_password(args.password.as_bytes()).unwrap();
     let authenticator = Arc::new(authenticator);

--- a/crates/hearth-types/src/lib.rs
+++ b/crates/hearth-types/src/lib.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ProcessId(pub u64);
 
 impl ProcessId {
@@ -15,16 +15,16 @@ impl ProcessId {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Deserialize, Serialize)]
 pub struct PeerId(pub u32);
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Deserialize, Serialize)]
 pub struct LocalProcessId(pub u32);
 
 /// Process-local identifiers for loaded assets.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Deserialize, Serialize)]
 pub struct AssetId(pub u32);
 
 /// Identifier for a lump (digest of BLAKE3 cryptographic hash).
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Deserialize, Serialize)]
 pub struct LumpId(pub [u8; 32]);


### PR DESCRIPTION
Overhauls basically all of `hearth-rpc` with a new peer-based API for exchanging `PeerProvider`s and `PeerApi`s.

Also adds a formal system for assigning peer IDs using a `ServerOffer` + `ClientOffer` exchange during initial client-server communication.

I've decided to remove trailing `...`s from log messages, such as in `Authenticating...` or `Binding...`. They don't really serve any real point. We may want to use Tracing spans for non-instantaneous operations, but that can be done in a future PR.