### PR TITLE
Add `hearth-ctl` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "crates/font-mud",
   "crates/hearth-client",
+  "crates/hearth-ctl",
   "crates/hearth-cognito",
   "crates/hearth-core",
   "crates/hearth-guest",

--- a/crates/hearth-ctl/Cargo.toml
+++ b/crates/hearth-ctl/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 clap = { version = "4.1", features = ["derive"] }
 hearth-ipc = { workspace = true }
 hearth-rpc = { workspace = true }
-tokio = { version = "1.24", features = ["macros", "net", "rt-multi-thread"] }
+tokio = { version = "1.24", features = ["macros", "net", "rt"] }

--- a/crates/hearth-ctl/Cargo.toml
+++ b/crates/hearth-ctl/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "hearth-ctl"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/crates/hearth-ctl/Cargo.toml
+++ b/crates/hearth-ctl/Cargo.toml
@@ -4,3 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+clap = { version = "4.1", features = ["derive"] }
+hearth-ipc = { workspace = true }
+hearth-rpc = { workspace = true }
+tokio = { version = "1.24", features = ["macros", "net", "rt-multi-thread"] }

--- a/crates/hearth-ctl/src/main.rs
+++ b/crates/hearth-ctl/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crates/hearth-ctl/src/main.rs
+++ b/crates/hearth-ctl/src/main.rs
@@ -12,7 +12,7 @@ pub enum Commands {
     Placeholder,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let args = Args::parse();
     let daemon = hearth_ipc::connect()

--- a/crates/hearth-ctl/src/main.rs
+++ b/crates/hearth-ctl/src/main.rs
@@ -1,3 +1,17 @@
+use clap::{Parser, Subcommand};
+
+/// Command-line interface (CLI) for interacting with a Hearth daemon over IPC.
+#[derive(Debug, Parser)]
+pub struct Args {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Commands {}
+
 fn main() {
+    let args = Args::parse();
+
     println!("Hello, world!");
 }

--- a/crates/hearth-ctl/src/main.rs
+++ b/crates/hearth-ctl/src/main.rs
@@ -8,10 +8,15 @@ pub struct Args {
 }
 
 #[derive(Debug, Subcommand)]
-pub enum Commands {}
+pub enum Commands {
+    Placeholder,
+}
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let args = Args::parse();
-
+    let daemon = hearth_ipc::connect()
+        .await
+        .expect("Failed to connect to Hearth daemon");
     println!("Hello, world!");
 }

--- a/crates/hearth-rpc/Cargo.toml
+++ b/crates/hearth-rpc/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 hearth-types = { workspace = true }
-remoc = { workspace = true, features = ["rtc"] }
+remoc = { workspace = true, features = ["robs", "rtc"] }
 serde = { workspace = true }


### PR DESCRIPTION
Adds a mostly-empty `hearth-ctl` crate for us to develop our Hearth CLI tools in.

Also, `hearth-rpc` was using remote collections even though that feature wasn't enabled on its Remoc dependency, so I fixed that.