### PR TITLE
Add lump store

### DIFF
--- a/crates/hearth-core/Cargo.toml
+++ b/crates/hearth-core/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+blake3 = "1.3"
+bytes = "1.3"
 hearth-ipc = { workspace = true }
 hearth-rpc = { workspace = true }
 tokio = { version = "1.24", features = ["full"] }

--- a/crates/hearth-core/src/api/lump_store.rs
+++ b/crates/hearth-core/src/api/lump_store.rs
@@ -1,0 +1,82 @@
+use hearth_rpc::remoc::robj::lazy_blob::LazyBlob;
+
+use super::*;
+
+pub struct LumpStoreImpl {}
+
+#[async_trait]
+impl LumpStore for LumpStoreImpl {
+    async fn upload_lump(&self, id: Option<LumpId>, data: LazyBlob) -> ResourceResult<LumpId> {
+        Ok(LumpId([0; 32]))
+    }
+
+    async fn download_lump(&self, id: LumpId) -> ResourceResult<LazyBlob> {
+        Err(ResourceError::Unavailable)
+    }
+}
+
+impl LumpStoreImpl {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bytes::Buf;
+
+    fn make_id(bytes: &[u8]) -> LumpId {
+        LumpId(
+            blake3::Hasher::new()
+                .update(bytes)
+                .finalize()
+                .as_bytes()
+                .to_owned(),
+        )
+    }
+
+    #[test]
+    fn create_store() {
+        let _store = LumpStoreImpl::new();
+    }
+
+    #[tokio::test]
+    async fn upload_then_download() {
+        const DATA: &[u8] = b"Hello, world!";
+        let id = make_id(DATA);
+        let data_blob = LazyBlob::new(DATA.into());
+        let store = LumpStoreImpl::new();
+
+        let uploaded = store
+            .upload_lump(Some(id), data_blob)
+            .await
+            .expect("Failed to upload");
+
+        assert_eq!(uploaded, id);
+
+        let downloaded = store
+            .download_lump(id)
+            .await
+            .expect("Failed to download")
+            .get()
+            .await
+            .unwrap();
+
+        assert_eq!(downloaded.chunk(), DATA);
+    }
+
+    #[tokio::test]
+    async fn wrong_id() {
+        const DATA: &[u8] = b"Hello, world!";
+        let wrong = make_id(b"Wrong data!");
+        let data_blob = LazyBlob::new(DATA.into());
+        let store = LumpStoreImpl::new();
+        let result = store.upload_lump(Some(wrong), data_blob).await;
+        match result {
+            Err(ResourceError::BadParams) => {}
+            result => panic!("Unexpected result: {:?}", result),
+        }
+    }
+}

--- a/crates/hearth-core/src/api/lump_store.rs
+++ b/crates/hearth-core/src/api/lump_store.rs
@@ -37,9 +37,51 @@ mod tests {
         )
     }
 
-    #[test]
-    fn create_store() {
-        let _store = LumpStoreImpl::new();
+    /// LazyBlobs don't work locally, so this needs to be pulled off in order
+    /// to get them to work in these tests.
+    async fn spawn_store() -> LumpStoreClient {
+        use remoc::rch::base::{Receiver, Sender};
+
+        let (a, b) = tokio::io::duplex(4096);
+        let (a_rx, a_tx) = tokio::io::split(a);
+        let (b_rx, b_tx) = tokio::io::split(b);
+
+        let join_a = tokio::spawn(async move {
+            let (conn, tx, _rx): (_, Sender<LumpStoreClient>, Receiver<()>) =
+                remoc::Connect::io(Default::default(), a_rx, a_tx)
+                    .await
+                    .unwrap();
+            tokio::task::spawn(conn);
+            tx
+        });
+
+        let join_b = tokio::spawn(async move {
+            let (conn, _tx, rx): (_, Sender<()>, Receiver<LumpStoreClient>) =
+                remoc::Connect::io(Default::default(), b_rx, b_tx)
+                    .await
+                    .unwrap();
+            tokio::task::spawn(conn);
+            rx
+        });
+
+        let store = LumpStoreImpl::new();
+        let store = Arc::new(store);
+        let (store_server, store) = LumpStoreServerShared::new(store, 1024);
+
+        tokio::spawn(async move {
+            store_server.serve(true).await;
+        });
+
+        let mut tx = join_a.await.unwrap();
+        let mut rx = join_b.await.unwrap();
+
+        tx.send(store).await.unwrap();
+        rx.recv().await.unwrap().unwrap()
+    }
+
+    #[tokio::test]
+    async fn create_store() {
+        let _store = spawn_store();
     }
 
     #[tokio::test]
@@ -47,7 +89,7 @@ mod tests {
         const DATA: &[u8] = b"Hello, world!";
         let id = make_id(DATA);
         let data_blob = LazyBlob::new(DATA.into());
-        let store = LumpStoreImpl::new();
+        let store = spawn_store().await;
 
         let uploaded = store
             .upload_lump(Some(id), data_blob)
@@ -72,7 +114,7 @@ mod tests {
         const DATA: &[u8] = b"Hello, world!";
         let wrong = make_id(b"Wrong data!");
         let data_blob = LazyBlob::new(DATA.into());
-        let store = LumpStoreImpl::new();
+        let store = spawn_store().await;
         let result = store.upload_lump(Some(wrong), data_blob).await;
         match result {
             Err(ResourceError::BadParams) => {}

--- a/crates/hearth-core/src/api/mod.rs
+++ b/crates/hearth-core/src/api/mod.rs
@@ -1,4 +1,6 @@
-use hearth_rpc::*;
+use std::sync::Arc;
+
+use hearth_rpc::{remoc::rtc::ServerShared, *};
 use hearth_types::*;
 use remoc::rtc::async_trait;
 use tracing::{debug, error, info};
@@ -25,4 +27,30 @@ impl PeerApi for PeerApiImpl {
     async fn get_lump_store(&self) -> CallResult<LumpStoreClient> {
         Ok(self.lump_store.to_owned())
     }
+}
+
+/// Helper function to create and spawn a [PeerApiImpl] and all of its
+/// subsystems.
+pub fn spawn_peer_api(info: PeerInfo) -> PeerApiClient {
+    debug!("Creating lump store");
+    let lump_store = lump_store::LumpStoreImpl::new();
+    let lump_store = Arc::new(lump_store);
+    let (lump_store_server, lump_store) = LumpStoreServerShared::new(lump_store, 1024);
+
+    debug!("Spawning lump store server thread");
+    tokio::spawn(async move {
+        lump_store_server.serve(true).await;
+    });
+
+    debug!("Creating peer API");
+    let peer_api = PeerApiImpl { info, lump_store };
+    let peer_api = Arc::new(peer_api);
+    let (peer_api_server, peer_api) = PeerApiServerShared::new(peer_api, 1024);
+
+    debug!("Spawning peer API server thread");
+    tokio::spawn(async move {
+        peer_api_server.serve(true).await;
+    });
+
+    peer_api
 }

--- a/crates/hearth-core/src/api/mod.rs
+++ b/crates/hearth-core/src/api/mod.rs
@@ -26,12 +26,3 @@ impl PeerApi for PeerApiImpl {
         Ok(self.lump_store.to_owned())
     }
 }
-
-/// Helper function to wait for Ctrl+C with nice logging.
-pub async fn wait_for_interrupt() {
-    debug!("Waiting for interrupt signal");
-    match tokio::signal::ctrl_c().await {
-        Ok(()) => info!("Interrupt signal received"),
-        Err(err) => error!("Interrupt await error: {:?}", err),
-    }
-}

--- a/crates/hearth-core/src/api/mod.rs
+++ b/crates/hearth-core/src/api/mod.rs
@@ -1,0 +1,37 @@
+use hearth_rpc::*;
+use hearth_types::*;
+use remoc::rtc::async_trait;
+use tracing::{debug, error, info};
+
+pub mod lump_store;
+
+/// The canonical [PeerApi] implementation, with full functionality.
+pub struct PeerApiImpl {
+    pub info: PeerInfo,
+    pub lump_store: LumpStoreClient,
+}
+
+#[async_trait]
+impl PeerApi for PeerApiImpl {
+    async fn get_info(&self) -> CallResult<PeerInfo> {
+        Ok(self.info.clone())
+    }
+
+    async fn get_process_store(&self) -> CallResult<ProcessStoreClient> {
+        error!("Process stores are unimplemented");
+        Err(remoc::rtc::CallError::RemoteForward)
+    }
+
+    async fn get_lump_store(&self) -> CallResult<LumpStoreClient> {
+        Ok(self.lump_store.to_owned())
+    }
+}
+
+/// Helper function to wait for Ctrl+C with nice logging.
+pub async fn wait_for_interrupt() {
+    debug!("Waiting for interrupt signal");
+    match tokio::signal::ctrl_c().await {
+        Ok(()) => info!("Interrupt signal received"),
+        Err(err) => error!("Interrupt await error: {:?}", err),
+    }
+}

--- a/crates/hearth-core/src/lib.rs
+++ b/crates/hearth-core/src/lib.rs
@@ -9,3 +9,12 @@ pub fn init_logging() {
         .event_format(format)
         .init();
 }
+
+/// Helper function to wait for Ctrl+C with nice logging.
+pub async fn wait_for_interrupt() {
+    debug!("Waiting for interrupt signal");
+    match tokio::signal::ctrl_c().await {
+        Ok(()) => info!("Interrupt signal received"),
+        Err(err) => error!("Interrupt await error: {:?}", err),
+    }
+}

--- a/crates/hearth-core/src/lib.rs
+++ b/crates/hearth-core/src/lib.rs
@@ -1,6 +1,5 @@
-use hearth_rpc::*;
-use remoc::rtc::async_trait;
-use tracing::{debug, error, info};
+/// Implementations of the `hearth-rpc` crate's RPC interfaces.
+pub mod api;
 
 /// Helper function to set up console logging with reasonable defaults.
 pub fn init_logging() {
@@ -9,30 +8,4 @@ pub fn init_logging() {
         .with_max_level(tracing::Level::DEBUG)
         .event_format(format)
         .init();
-}
-
-/// The canonical [PeerApi] implementation, with full functionality.
-pub struct PeerApiImpl {
-    pub info: PeerInfo,
-}
-
-#[async_trait]
-impl PeerApi for PeerApiImpl {
-    async fn get_info(&self) -> CallResult<PeerInfo> {
-        Ok(self.info.clone())
-    }
-
-    async fn get_process_store(&self) -> CallResult<ProcessStoreClient> {
-        error!("Process stores are unimplemented");
-        Err(remoc::rtc::CallError::RemoteForward)
-    }
-}
-
-/// Helper function to wait for Ctrl+C with nice logging.
-pub async fn wait_for_interrupt() {
-    debug!("Waiting for interrupt signal");
-    match tokio::signal::ctrl_c().await {
-        Ok(()) => info!("Interrupt signal received"),
-        Err(err) => error!("Interrupt await error: {:?}", err),
-    }
 }

--- a/crates/hearth-core/src/lib.rs
+++ b/crates/hearth-core/src/lib.rs
@@ -1,3 +1,5 @@
+use tracing::{debug, error, info};
+
 /// Implementations of the `hearth-rpc` crate's RPC interfaces.
 pub mod api;
 

--- a/crates/hearth-rpc/Cargo.toml
+++ b/crates/hearth-rpc/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 hearth-types = { workspace = true }
-remoc = { workspace = true, features = ["robs", "rtc"] }
+remoc = { workspace = true, features = ["robj", "robs", "rtc"] }
 serde = { workspace = true }

--- a/crates/hearth-rpc/src/lib.rs
+++ b/crates/hearth-rpc/src/lib.rs
@@ -1,5 +1,6 @@
 use hearth_types::*;
 
+use remoc::robj::lazy_blob::LazyBlob;
 use remoc::robs::hash_map::HashMapSubscription;
 use remoc::robs::list::ListSubscription;
 use remoc::rtc::{remote, CallError};
@@ -63,6 +64,9 @@ pub trait PeerApi {
 
     /// Gets this peer's process store.
     async fn get_process_store(&self) -> CallResult<ProcessStoreClient>;
+
+    /// Gets this peer's lump store.
+    async fn get_lump_store(&self) -> CallResult<LumpStoreClient>;
 }
 
 /// A peer's metadata.
@@ -115,6 +119,21 @@ pub trait ProcessStore {
     async fn follow_service_list(&self) -> CallResult<HashMapSubscription<String, LocalProcessId>>;
 
     // TODO Lunatic Supervisor-like child API?
+}
+
+/// Interface to a peer's local lumps.
+#[remote]
+pub trait LumpStore {
+    /// Uploads a new lump to this store.
+    ///
+    /// Will skip downloading the lump data if the ID is already found in the
+    /// store. If the data's calculated hash does not match the given hash,
+    /// this request will fail.
+    async fn upload_lump(&self, id: LumpId, data: LazyBlob) -> CallResult<LumpId>;
+
+    /// Downloads a lump from this store. Returns `None` if the lump was not
+    /// found in this store.
+    async fn download_lump(&self, id: LumpId) -> CallResult<Option<LazyBlob>>;
 }
 
 /// Log event emitted by a process.

--- a/crates/hearth-rpc/src/lib.rs
+++ b/crates/hearth-rpc/src/lib.rs
@@ -147,6 +147,9 @@ pub trait ProcessStore {
 pub trait LumpStore {
     /// Uploads a new lump to this store.
     ///
+    /// If the uploading of the lump fails, this request will fail with
+    /// [ResourceResult::Unavailable].
+    ///
     /// Has an optional [LumpId] parameter to skip the uploading of a lump if
     /// the lump is already available. If an ID is provided but the data's
     /// hash does not match that ID, this request will fail with

--- a/crates/hearth-server/src/main.rs
+++ b/crates/hearth-server/src/main.rs
@@ -45,18 +45,7 @@ async fn main() {
 
     debug!("Creating peer API");
     let peer_info = PeerInfo { nickname: None };
-    let peer_api = hearth_core::PeerApiImpl {
-        info: peer_info.clone(),
-    };
-
-    let peer_api = Arc::new(peer_api);
-    let (peer_api_server, peer_api) =
-        PeerApiServerShared::<_, remoc::codec::Default>::new(peer_api, 1024);
-
-    debug!("Spawning peer API server thread");
-    tokio::spawn(async move {
-        peer_api_server.serve(true).await;
-    });
+    let peer_api = hearth_core::api::spawn_peer_api(peer_info.clone());
 
     debug!("Creating peer provider");
     let mut peer_provider = PeerProviderImpl::new();

--- a/crates/hearth-server/src/main.rs
+++ b/crates/hearth-server/src/main.rs
@@ -240,8 +240,11 @@ struct PeerProviderImpl {
 
 #[async_trait]
 impl PeerProvider for PeerProviderImpl {
-    async fn find_peer(&self, id: PeerId) -> CallResult<Option<PeerApiClient>> {
-        Ok(self.peer_apis.get(&id).cloned())
+    async fn find_peer(&self, id: PeerId) -> ResourceResult<PeerApiClient> {
+        self.peer_apis
+            .get(&id)
+            .cloned()
+            .ok_or(ResourceError::Unavailable)
     }
 
     async fn follow_peer_list(&self) -> CallResult<HashMapSubscription<PeerId, PeerInfo>> {

--- a/crates/hearth-types/src/lib.rs
+++ b/crates/hearth-types/src/lib.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Deserialize, Serialize)]
@@ -28,3 +30,13 @@ pub struct AssetId(pub u32);
 /// Identifier for a lump (digest of BLAKE3 cryptographic hash).
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Deserialize, Serialize)]
 pub struct LumpId(pub [u8; 32]);
+
+impl Display for LumpId {
+    fn fmt(&self, fmt: &mut Formatter) -> FmtResult {
+        for byte in self.0.iter() {
+            write!(fmt, "{:02x}", byte)?;
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This adds a lump store RPC interface, an implementation of that in `hearth-core`, and some passing unit tests demonstrating how it's used.

I've also added the `ResourceError` and `ResourceResult` types to `hearth-rpc` for better error results in our RPC calls.

Read the commit messages for more goodies!