### PR TITLE
core: lump asset loading

### DIFF
--- a/crates/hearth-core/src/asset.rs
+++ b/crates/hearth-core/src/asset.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::lump::LumpStoreImpl;
 use hearth_rpc::remoc::rtc::async_trait;
 use sharded_slab::Slab;
 use tracing::{debug, error};
@@ -50,15 +51,19 @@ impl<T: AssetLoader> AssetPoolImpl<T> {
     }
 }
 
-#[derive(Default)]
 pub struct AssetStore {
     class_to_pool: HashMap<String, usize>,
     pools: Vec<Box<dyn AssetPool>>,
+    lump_store: Arc<LumpStoreImpl>,
 }
 
 impl AssetStore {
-    pub fn new() -> Self {
-        Default::default()
+    pub fn new(lump_store: Arc<LumpStoreImpl>) -> Self {
+        Self {
+            class_to_pool: HashMap::new(),
+            pools: Vec::new(),
+            lump_store,
+        }
     }
 
     pub fn add_loader(&mut self, class: String, loader: impl AssetLoader) {

--- a/crates/hearth-core/src/asset.rs
+++ b/crates/hearth-core/src/asset.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::lump::LumpStoreImpl;
-use hearth_rpc::remoc::rtc::async_trait;
+use hearth_rpc::{hearth_types, remoc};
+use hearth_types::LumpId;
+use remoc::rtc::async_trait;
 use sharded_slab::Slab;
 use tracing::{debug, error};
 
@@ -84,11 +86,12 @@ impl AssetStore {
         self.class_to_pool.contains_key(class)
     }
 
-    pub async fn load_asset(&self, class: &str, data: &[u8]) -> Handle {
+    pub async fn load_asset(&self, class: &str, lump: &LumpId) -> Handle {
         // TODO error reporting with eyre
         let pool_id = *self.class_to_pool.get(class).unwrap();
         let pool = self.pools.get(pool_id).unwrap();
-        let asset_id = pool.load_asset(data).await;
+        let data = self.lump_store.get_lump(lump).await.unwrap();
+        let asset_id = pool.load_asset(&data).await;
 
         Handle {
             count: Arc::new(()),

--- a/crates/hearth-core/src/lump.rs
+++ b/crates/hearth-core/src/lump.rs
@@ -1,15 +1,15 @@
 use std::collections::HashMap;
 
-use bytes::Buf;
+use bytes::{Buf, Bytes};
 use hearth_rpc::*;
 use hearth_types::*;
-use remoc::robj::lazy_blob::{LazyBlob, Provider as BlobProvider};
+use remoc::robj::lazy_blob::LazyBlob;
 use remoc::rtc::async_trait;
 use tokio::sync::RwLock;
 use tracing::error;
 
 struct Lump {
-    provider: BlobProvider,
+    data: Bytes,
     blob: LazyBlob,
 }
 
@@ -53,8 +53,9 @@ impl LumpStore for LumpStoreImpl {
             }
         }
 
-        let (blob, provider) = LazyBlob::provided(data.into());
-        let lump = Lump { provider, blob };
+        let data = Bytes::from(data);
+        let blob = LazyBlob::new(data.clone());
+        let lump = Lump { data, blob };
         let mut store = self.store.write().await;
         store.insert(checked_id, lump);
         Ok(checked_id)

--- a/crates/hearth-core/src/lump.rs
+++ b/crates/hearth-core/src/lump.rs
@@ -77,6 +77,14 @@ impl LumpStoreImpl {
             store: Default::default(),
         }
     }
+
+    pub async fn get_lump(&self, id: &LumpId) -> Option<Bytes> {
+        self.store
+            .read()
+            .await
+            .get(id)
+            .map(|lump| lump.data.clone())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Makes `AssetStore` depend on a `LumpStoreImpl` and changes `AssetStore::load_asset()` from using a byte slice to using a lump ID instead.