### PR TITLE
core: IPC processes

### DIFF
--- a/crates/hearth-client/src/main.rs
+++ b/crates/hearth-client/src/main.rs
@@ -101,7 +101,7 @@ async fn main() {
 
     let mut builder = RuntimeBuilder::new();
     builder.add_plugin(hearth_cognito::WasmPlugin::new());
-    
+
     let runtime = builder.run(config);
     let peer_api = runtime.clone().serve_peer_api();
 
@@ -125,6 +125,7 @@ async fn main() {
     let daemon_offer = DaemonOffer {
         peer_provider: offer.peer_provider,
         peer_id: offer.new_id,
+        process_factory: runtime.process_factory_client.clone(),
     };
 
     hearth_ipc::listen(daemon_listener, daemon_offer);

--- a/crates/hearth-core/src/process.rs
+++ b/crates/hearth-core/src/process.rs
@@ -265,16 +265,19 @@ impl ProcessStoreImpl {
     }
 
     async fn send_message(&self, dst: LocalProcessId, msg: Message) {
-        if let Some(wrapper) = self.processes.get(dst.0 as usize) {
-            // TODO i'm too high to tell if this error catching is necessary
-            match wrapper.mailbox_tx.send(msg).await {
-                Ok(()) => {}
-                Err(err) => {
-                    error!("Message mailbox sending error: {:?}", err);
-                }
-            }
+        let sender = if let Some(wrapper) = self.processes.get(dst.0 as usize) {
+            wrapper.mailbox_tx.clone()
         } else {
             // TODO error handling for when process ID is invalid
+            return;
+        };
+
+        // TODO i'm too high to tell if this error catching is necessary
+        match sender.send(msg).await {
+            Ok(()) => {}
+            Err(err) => {
+                error!("Message mailbox sending error: {:?}", err);
+            }
         }
     }
 

--- a/crates/hearth-core/src/process.rs
+++ b/crates/hearth-core/src/process.rs
@@ -12,8 +12,9 @@ use std::sync::{Arc, Weak};
 
 use hearth_rpc::remoc::robs::hash_map::HashMapSubscription;
 use hearth_rpc::remoc::rtc::ServerShared;
-use hearth_rpc::*;
+use hearth_rpc::{Message as RpcMessage, *};
 use hearth_types::*;
+use remoc::rch::{mpsc as remoc_mpsc, watch as remoc_watch};
 use remoc::robs::hash_map::ObservableHashMap;
 use remoc::robs::list::{ListSubscription, ObservableList, ObservableListDistributor};
 use remoc::rtc::async_trait;
@@ -144,6 +145,97 @@ impl ProcessContext {
     /// Adds a log event to this process's log.
     pub fn log(&mut self, event: ProcessLogEvent) {
         self.log.push(event);
+    }
+}
+
+struct RemoteProcess {
+    info: ProcessInfo,
+    mailbox: remoc_mpsc::Sender<RpcMessage>,
+    outgoing: remoc_mpsc::Receiver<RpcMessage>,
+    is_alive: remoc_watch::Sender<bool>,
+    log: remoc_mpsc::Receiver<ProcessLogEvent>,
+}
+
+#[async_trait]
+impl Process for RemoteProcess {
+    fn get_info(&self) -> ProcessInfo {
+        self.info.clone()
+    }
+
+    async fn run(&mut self, mut ctx: ProcessContext) {
+        loop {
+            tokio::select! {
+                msg = ctx.mailbox.recv() => self.on_recv(msg).await,
+                _ = ctx.is_alive.changed() => self.on_is_alive(&mut ctx).await,
+                msg = self.outgoing.recv() => self.on_outgoing(&mut ctx, msg).await,
+                log = self.log.recv() => self.on_log(&mut ctx, log).await,
+            }
+        }
+    }
+}
+
+impl RemoteProcess {
+    async fn on_recv(&mut self, msg: Option<Message>) {
+        let msg = match msg {
+            Some(msg) => msg,
+            None => return,
+        };
+
+        let msg = RpcMessage {
+            pid: msg.sender,
+            data: msg.data,
+        };
+
+        let _ = self.mailbox.send(msg).await; // TODO autokill on hang up?
+    }
+
+    async fn on_is_alive(&mut self, ctx: &mut ProcessContext) {
+        if !ctx.is_alive() {
+            let _ = self.is_alive.send(false); // ignore result; no biggie if the remote hangs up
+        }
+    }
+
+    async fn on_outgoing(
+        &mut self,
+        ctx: &mut ProcessContext,
+        msg: Result<Option<RpcMessage>, remoc_mpsc::RecvError>,
+    ) {
+        if let Some(msg) = self.handle_recv_result(msg) {
+            ctx.send_message(msg.pid, msg.data).await;
+        }
+    }
+
+    async fn on_log(
+        &mut self,
+        ctx: &mut ProcessContext,
+        log: Result<Option<ProcessLogEvent>, remoc_mpsc::RecvError>,
+    ) {
+        if let Some(log) = self.handle_recv_result(log) {
+            ctx.log(log);
+        }
+    }
+
+    fn handle_recv_result<T>(
+        &mut self,
+        result: Result<Option<T>, remoc_mpsc::RecvError>,
+    ) -> Option<T> {
+        match result {
+            Ok(Some(val)) => Some(val),
+            Ok(None) => {
+                debug!("RemoteProcess channel hung up (end of channel)");
+                // remote hung up
+                None
+            }
+            Err(err) if err.is_final() => {
+                debug!("RemoteProcess channel hung up (RecvError::is_final() == true)");
+                // remote hung up
+                None
+            }
+            Err(err) => {
+                error!("RemoteProcess recv() error: {:?}", err);
+                None
+            }
+        }
     }
 }
 

--- a/crates/hearth-rpc/src/lib.rs
+++ b/crates/hearth-rpc/src/lib.rs
@@ -156,7 +156,7 @@ pub struct ProcessOffer {
     pub outgoing: mpsc::Sender<Message>,
 
     /// The new PID for this process.
-    pub pid: ProcessId,
+    pub pid: LocalProcessId,
 }
 
 /// Interface to a single process.

--- a/crates/hearth-rpc/src/lib.rs
+++ b/crates/hearth-rpc/src/lib.rs
@@ -1,5 +1,6 @@
 use hearth_types::*;
 
+use remoc::rch::{mpsc, watch};
 use remoc::robj::lazy_blob::LazyBlob;
 use remoc::robs::hash_map::HashMapSubscription;
 use remoc::robs::list::ListSubscription;
@@ -68,6 +69,10 @@ pub struct DaemonOffer {
 
     /// The ID of this daemon's peer.
     pub peer_id: PeerId,
+
+    /// The [ProcessFactory] on this daemon. Can be used to spawn
+    /// out-of-runtime processes.
+    pub process_factory: ProcessFactoryClient,
 }
 
 /// Top-level interface for a peer. Provides access to its metadata as well as
@@ -133,6 +138,30 @@ pub trait ProcessStore {
     // TODO Lunatic Supervisor-like child API?
 }
 
+/// Spawning interface to a peer's process store for out-of-runtime processes.
+#[remote]
+pub trait ProcessFactory {
+    /// Spawns a remote process.
+    ///
+    /// Implement [ProcessBase], serve it, then send a client to this function
+    /// to add the process to the process store.
+    async fn spawn(&self, process: ProcessBaseClient, info: ProcessInfo) -> CallResult<ProcessOffer>;
+}
+
+/// The result of [ProcessFactory::ProcessOffer]. Sent from the runtime to an
+/// IPC client as part of the spawning of an out-of-runtime process.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ProcessOffer {
+    /// A sender for outgoing process messages.
+    ///
+    /// The destination process ID for each message is passed through the
+    /// [Message::pid] field.
+    pub outgoing: mpsc::Sender<Message>,
+
+    /// The new PID for this process.
+    pub pid: ProcessId,
+}
+
 /// Interface to a single process.
 ///
 /// All of these methods still function when the process is dead.
@@ -148,6 +177,39 @@ pub trait ProcessApi {
     ///
     /// Even if the process is dead, this will still return a full log history.
     async fn follow_log(&self) -> CallResult<ListSubscription<ProcessLogEvent>>;
+}
+
+/// The base functionality of a single process.
+///
+/// While [ProcessApi] defines an interface to interact with a running process,
+/// this is instead an interface for implementing a process itself. This is
+/// intended to be implemented by an IPC client for creating native IPC
+/// processes that execute outside of the main Hearth runtime. Because only
+/// processes can send messages to other processes, this is a necessary
+/// prerequisite for IPC to interact with Hearth processes via messages.
+#[remote]
+pub trait ProcessBase {
+    /// Gets a sender to this process's mailbox.
+    ///
+    /// The `pid` field represents the sender of the message.
+    async fn get_mailbox(&self) -> CallResult<mpsc::Sender<Message>>;
+
+    /// Gets a watcher to this process's alive status.
+    async fn get_is_alive(&self) -> CallResult<watch::Receiver<bool>>;
+
+    /// Subscribes this process's log.
+    async fn follow_log(&self) -> CallResult<ListSubscription<ProcessLogEvent>>;
+}
+
+/// A single message between processes.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Message {
+    /// The ID of the involved process. May be either the sender or receiver,
+    /// depending on the context this struct is used in.
+    pub pid: ProcessId,
+
+    /// The data in this message.
+    pub data: Vec<u8>,
 }
 
 /// Interface to a peer's local lumps.

--- a/crates/hearth-server/src/main.rs
+++ b/crates/hearth-server/src/main.rs
@@ -88,6 +88,7 @@ async fn main() {
     let daemon_offer = DaemonOffer {
         peer_provider: peer_provider_client.to_owned(),
         peer_id: SELF_PEER_ID,
+        process_factory: runtime.process_factory_client.clone(),
     };
 
     listen(listener, peer_provider, peer_provider_client, authenticator);


### PR DESCRIPTION
- Adds `ProcessFactory`, `ProcessBase` and `ProcessOffer` to `hearth-rpc`, which are used for spawning out-of-runtime processes within the process store.
- Adds `RemoteProcess` to `hearth-core`, which is constructed from a `ProcessBase` and forwards all communications to and from the remote process.
- Implements `ProcessFactory` for `ProcessFactoryImpl` in `hearth-core`, and serves it as part of a runtime.
- Passes a `ProcessFactoryClient` in `DaemonOffer` to IPC clients.