### PR TITLE
Add dominion crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+  "crates/dominion",
   "crates/font-mud",
   "crates/hearth-client",
   "crates/hearth-ctl",

--- a/crates/dominion/Cargo.toml
+++ b/crates/dominion/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "dominion"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+bytemuck = "1"
+fortuples = "0.9"

--- a/crates/dominion/src/component.rs
+++ b/crates/dominion/src/component.rs
@@ -1,0 +1,208 @@
+// Copyright (c) 2023 the Hearth contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::TypeId;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use bytemuck::Pod;
+use fortuples::fortuples;
+
+/// An identifier for a component.
+///
+/// Component IDs can be generated at either runtime through custom IDs or
+/// at compile-time with Rust types. This fusion of runtime and compile-time
+/// component logic allows Dominion to provide both scriptable runtime logic
+/// and idiomatic usage from Rust.
+///
+/// The upper bit of the ID is set if the ID has been generated from a Rust
+/// type, and is unset if it's a custom runtime ID.
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ComponentId(u64);
+
+impl ComponentId {
+    const IS_TYPE_MASK: u64 = !(u64::MAX >> 1);
+
+    pub fn is_type(&self) -> bool {
+        (self.0 & Self::IS_TYPE_MASK) != 0
+    }
+
+    pub fn from_type<T: 'static>() -> Self {
+        let id = TypeId::of::<T>();
+        let mut hasher = DefaultHasher::new();
+        id.hash(&mut hasher);
+
+        let hash = hasher.finish();
+        Self(hash | Self::IS_TYPE_MASK)
+    }
+
+    pub fn from_val_type<T: 'static>(_val: &T) -> Self {
+        Self::from_type::<T>()
+    }
+
+    pub fn from_custom(id: u64) -> Self {
+        let mut hasher = DefaultHasher::new();
+        hasher.write_u64(id);
+        let hash = hasher.finish();
+        Self(hash & !Self::IS_TYPE_MASK)
+    }
+}
+
+/// Information about a component.
+///
+/// `size` and `alignment` are used for determining the memory of the layout
+/// of the component, and `name` is an optional debug label for this component. 
+#[derive(Clone, Debug)]
+pub struct ComponentInfo {
+    pub name: Option<String>,
+    pub size: usize,
+    pub alignment: usize,
+}
+
+impl ComponentInfo {
+    pub fn from_type<T: 'static>() -> Self {
+        Self {
+            name: Some(std::any::type_name::<T>().to_string()),
+            size: std::mem::size_of::<T>(),
+            alignment: std::mem::align_of::<T>(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ComponentData<'a> {
+    pub id: ComponentId,
+    pub data: &'a [u8],
+}
+
+pub trait AsComponentData {
+    fn as_component_data(&self) -> ComponentData<'_>;
+}
+
+impl<'a> AsComponentData for ComponentData<'a> {
+    fn as_component_data(&self) -> ComponentData<'a> {
+        Self {
+            id: self.id,
+            data: self.data,
+        }
+    }
+}
+
+impl<'a, T: Pod> AsComponentData for T {
+    fn as_component_data(&self) -> ComponentData<'_> {
+        ComponentData {
+            id: ComponentId::from_type::<T>(),
+            data: bytemuck::bytes_of(self),
+        }
+    }
+}
+
+pub trait AsMultiComponentData {
+    fn len(&self) -> usize;
+    fn get_data<'a>(&'a self, datas: &mut Vec<ComponentData<'a>>);
+}
+
+fortuples! {
+    #[tuples::max_size(8)]
+    impl AsMultiComponentData for #Tuple
+    where
+        #(#Member: AsComponentData),*
+    {
+        fn len(&self) -> usize {
+            #len(Tuple)
+        }
+
+        fn get_data<'a>(&'a self, datas: &mut Vec<ComponentData<'a>>) {
+            datas.extend_from_slice(&[
+                #(#self.as_component_data()),*
+            ]);
+        }
+    }
+}
+
+/// A list of components.
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub struct Layout(Vec<ComponentId>);
+
+impl From<Vec<ComponentId>> for Layout {
+    fn from(mut src: Vec<ComponentId>) -> Self {
+        src.sort_unstable_by_key(|cid| cid.0);
+        Self(src)
+    }
+}
+
+impl Layout {
+    pub fn is_subset(&self, parent: &Layout) -> bool {
+        // TODO this can be improved by iterating both layouts at once.
+        self.0.iter().all(|cid| parent.0.contains(cid))
+    }
+
+    pub fn insert_cid(&mut self, cid: ComponentId) {
+        if !self.0.contains(&cid) {
+            self.0.push(cid);
+        }
+
+        // TODO please insert without doing a full sort afterwards...
+        self.0.sort_by_key(|cid| cid.0);
+    }
+
+    pub fn insert<T: 'static>(&mut self) {
+        self.insert_cid(ComponentId::from_type::<T>());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cid_from_type() {
+        let f32_id = ComponentId::from_type::<f32>();
+        let u32_id = ComponentId::from_type::<u32>();
+        assert!(f32_id.is_type());
+        assert!(u32_id.is_type());
+        assert_ne!(f32_id, u32_id);
+    }
+
+    #[test]
+    fn layout_eq() {
+        let cid1 = ComponentId::from_custom(0);
+        let cid2 = ComponentId::from_custom(1);
+        let cid3 = ComponentId::from_custom(2);
+
+        let l1 = Layout::from(vec![cid1, cid2]);
+        let l2 = Layout::from(vec![cid2, cid1]);
+        let l3 = Layout::from(vec![cid1, cid2, cid3]);
+        let l4 = Layout::from(vec![cid3, cid2, cid1]);
+
+        assert_eq!(l1, l2);
+        assert_eq!(l3, l4);
+        assert_ne!(l1, l3);
+        assert_ne!(l2, l4);
+    }
+
+    #[test]
+    fn layout_subset() {
+        let cid1 = ComponentId::from_custom(0);
+        let cid2 = ComponentId::from_custom(1);
+        let cid3 = ComponentId::from_custom(2);
+
+        let l1 = Layout::from(vec![cid1, cid2]);
+        let l2 = Layout::from(vec![cid1, cid2, cid3]);
+
+        assert!(l1.is_subset(&l2));
+        assert!(!l2.is_subset(&l1));
+    }
+}

--- a/crates/dominion/src/lib.rs
+++ b/crates/dominion/src/lib.rs
@@ -1,0 +1,197 @@
+// Copyright (c) 2023 the Hearth contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use bytemuck::{AnyBitPattern, Pod};
+
+pub mod component;
+pub mod query;
+
+use component::*;
+
+pub type EntityId = u64;
+
+pub struct World {
+    entities: HashMap<EntityId, HashMap<ComponentId, Vec<u8>>>,
+    components: HashMap<ComponentId, ComponentInfo>,
+    next_id: EntityId,
+}
+
+impl World {
+    pub fn new() -> Self {
+        Self {
+            entities: HashMap::new(),
+            components: Default::default(),
+            next_id: 0,
+        }
+    }
+
+    /// Allocates an empty entity.
+    pub fn spawn(&mut self) -> EntityId {
+        let id = self.next_id;
+        self.entities.insert(id, Default::default());
+        self.next_id += 1;
+        id
+    }
+
+    /// Destroys an entity.
+    pub fn destroy(&mut self, e: EntityId) {
+        self.entities.remove(&e);
+    }
+
+    /// Inserts a component into an entity.
+    pub fn insert<T: AsComponentData>(&mut self, e: EntityId, c: T) {
+        if let Some(e) = self.entities.get_mut(&e) {
+            let data = c.as_component_data();
+            let cid = data.id;
+            let storage = data.data.to_vec();
+            e.insert(cid, storage);
+        }
+    }
+
+    /// Removes a component from an entity.
+    pub fn remove<T: Pod>(&mut self, e: EntityId) {
+        if let Some(e) = self.entities.get_mut(&e) {
+            let cid = ComponentId::from_type::<T>();
+            e.remove(&cid);
+        }
+    }
+
+    /// Looks up a component on an entity.
+    pub fn get<T: AnyBitPattern>(&self, e: EntityId) -> Option<&T> {
+        let e = self.entities.get(&e)?;
+        let cid = ComponentId::from_type::<T>();
+        let c = e.get(&cid)?;
+        Some(bytemuck::from_bytes(c))
+    }
+
+    /// Mutably looks up a component on an entity.
+    pub fn get_mut<T: Pod>(&mut self, e: EntityId) -> Option<&mut T> {
+        let e = self.entities.get_mut(&e)?;
+        let cid = ComponentId::from_type::<T>();
+        let c = e.get_mut(&cid)?;
+        Some(bytemuck::from_bytes_mut(c))
+    }
+
+    /// Gets the layout of an entity.
+    ///
+    /// Returns [None] if the entity does not exist.
+    pub fn get_layout(&self, e: EntityId) -> Option<Layout> {
+        let e = self.entities.get(&e)?;
+        Some(e.keys().copied().collect::<Vec<ComponentId>>().into())
+    }
+
+    /// Creates a new entity with the given components.
+    pub fn push<T: AsMultiComponentData>(&mut self, components: T) -> EntityId {
+        let mut datas = Vec::with_capacity(components.len());
+        let e = self.spawn();
+        components.get_data(&mut datas);
+
+        for data in datas {
+            self.insert(e, data);
+        }
+
+        e
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_world() {
+        World::new();
+    }
+
+    #[test]
+    fn spawn() {
+        let mut w = World::new();
+        let e1 = w.spawn();
+        let e2 = w.spawn();
+        assert_ne!(e1, e2);
+    }
+
+    #[test]
+    fn insert_get() {
+        let mut w = World::new();
+        let e = w.spawn();
+        let c = 42u8;
+        w.insert(e, c);
+        assert_eq!(w.get(e), Some(&c));
+    }
+
+    #[test]
+    fn insert_get_mut() {
+        let mut w = World::new();
+        let e = w.spawn();
+        let c = 42u8;
+        let d = 36u8;
+        let result = c + d;
+        w.insert(e, c);
+        *w.get_mut::<u8>(e).unwrap() += d;
+        assert_eq!(w.get(e), Some(&result));
+    }
+
+    #[test]
+    fn insert_remove() {
+        let mut w = World::new();
+        let e = w.spawn();
+        let c = 42u8;
+        w.insert(e, c);
+        w.remove::<u8>(e);
+        assert_eq!(w.get::<u8>(e), None);
+    }
+
+    #[test]
+    fn insert_layout() {
+        let mut w = World::new();
+        let e = w.spawn();
+        let c = 42u8;
+        let cid = ComponentId::from_val_type(&c);
+        w.insert(e, c);
+        assert_eq!(w.get_layout(e), Some(vec![cid].into()));
+    }
+
+    #[test]
+    fn push_single_get() {
+        let mut w = World::new();
+        let val = 42u8;
+        let e = w.push((val,));
+        assert_eq!(w.get(e), Some(&val));
+    }
+
+    #[test]
+    fn push_tuple_get() {
+        let mut w = World::new();
+        let val1 = 42u8;
+        let val2 = 320u32;
+        let e = w.push((val1, val2));
+        assert_eq!(w.get(e), Some(&val1));
+        assert_eq!(w.get(e), Some(&val2));
+    }
+
+    #[test]
+    fn push_tuple_layout() {
+        let mut w = World::new();
+        let val1 = 42u8;
+        let val2 = 320u32;
+        let e = w.push((val1, val2));
+        let cid1 = ComponentId::from_val_type(&val1);
+        let cid2 = ComponentId::from_val_type(&val2);
+        assert_eq!(w.get_layout(e), Some(vec![cid1, cid2].into()));
+    }
+}

--- a/crates/dominion/src/query.rs
+++ b/crates/dominion/src/query.rs
@@ -1,0 +1,272 @@
+// Copyright (c) 2023 the Hearth contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::marker::PhantomData;
+
+use crate::component::{ComponentId, Layout};
+use crate::{EntityId, World};
+
+use bytemuck::{AnyBitPattern, Pod};
+use fortuples::fortuples;
+
+#[derive(Default)]
+pub struct QueryParameters {
+    pub view: Layout,
+}
+
+impl QueryParameters {
+    pub fn include<T: 'static>(&mut self) {
+        self.view.insert::<T>();
+    }
+
+    pub fn include_cid(&mut self, cid: ComponentId) {
+        self.view.insert_cid(cid);
+    }
+}
+
+pub struct Query {
+    params: QueryParameters,
+}
+
+impl Query {
+    pub fn new(params: QueryParameters) -> Self {
+        Self { params }
+    }
+
+    pub fn evaluate<'a>(&self, w: &'a mut World) -> QueryResult<'a> {
+        let mut entities = Vec::new();
+
+        for e in w.entities.keys() {
+            let layout = w.get_layout(*e).unwrap();
+            if self.params.view.is_subset(&layout) {
+                entities.push(*e);
+            }
+        }
+
+        QueryResult { entities, world: w }
+    }
+}
+
+pub struct StaticQuery<T> {
+    inner: Query,
+    _view: PhantomData<T>,
+}
+
+impl<T: IntoQuery> StaticQuery<T> {
+    pub fn iter_mut<'a>(&self, w: &'a mut World) -> QueryViewIter<'a, T> {
+        let result = self.inner.evaluate(w);
+
+        QueryViewIter {
+            result,
+            idx: 0,
+            _view: Default::default(),
+        }
+    }
+}
+
+pub struct QueryViewIter<'a, T> {
+    result: QueryResult<'a>,
+    idx: usize,
+    _view: PhantomData<T>,
+}
+
+impl<'a, T: Fetch> Iterator for QueryViewIter<'a, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        let e = self.result.entities.get(self.idx)?;
+        self.idx += 1;
+        Some(T::fetch(*e, self.result.world))
+    }
+}
+
+pub struct QueryResult<'a> {
+    entities: Vec<EntityId>,
+    world: &'a mut World,
+}
+
+impl<'a> QueryResult<'a> {
+    pub fn len(&self) -> usize {
+        self.entities.len()
+    }
+
+    pub fn write_entities(&self, dst: &mut [EntityId]) {
+        assert_eq!(
+            dst.len(),
+            self.len(),
+            "Destination for QueryResult::write_entities() is missized."
+        );
+
+        dst.copy_from_slice(self.entities.as_slice());
+    }
+
+    pub fn write_components<T: AnyBitPattern>(&self, dst: &mut [T]) {
+        assert_eq!(
+            dst.len(),
+            self.len(),
+            "Destination for QueryResult::write_components<{}>() is missized.",
+            std::any::type_name::<T>()
+        );
+
+        for (e, dst) in self.entities.iter().zip(dst.iter_mut()) {
+            // TODO better panic message on unwrap
+            *dst = *self.world.get::<T>(*e).unwrap();
+        }
+    }
+
+    pub fn get_entities(&self) -> Vec<EntityId> {
+        let mut dst = Vec::new();
+        dst.resize(self.len(), EntityId::default());
+        self.write_entities(&mut dst);
+        dst
+    }
+
+    pub fn get_components<T: AnyBitPattern>(&self) -> Vec<T> {
+        let len = self.len();
+        let mut dst = Vec::with_capacity(len);
+        unsafe { dst.set_len(len) };
+        self.write_components(&mut dst);
+        dst
+    }
+}
+
+pub trait IntoQuery: Sized {
+    fn query() -> StaticQuery<Self>;
+}
+
+impl<T: Fetch> IntoQuery for T {
+    fn query() -> StaticQuery<Self> {
+        let mut params = Default::default();
+        T::build_query(&mut params);
+
+        StaticQuery {
+            inner: Query::new(params),
+            _view: Default::default(),
+        }
+    }
+}
+
+pub trait Fetch: Sized {
+    // TODO this is only temporary; it doesn't create any generic/efficient iterators.
+    fn fetch(e: EntityId, w: &mut World) -> Self;
+    fn build_query(query: &mut QueryParameters);
+}
+
+impl<'a, T: Pod + 'static> Fetch for &'a T {
+    fn fetch(e: EntityId, w: &mut World) -> Self {
+        unsafe { std::mem::transmute(w.get::<T>(e).unwrap()) }
+    }
+
+    fn build_query(query: &mut QueryParameters) {
+        query.include::<T>();
+    }
+}
+
+impl<'a, T: Pod + 'static> Fetch for &'a mut T {
+    fn fetch(e: EntityId, w: &mut World) -> Self {
+        unsafe { std::mem::transmute(w.get_mut::<T>(e).unwrap()) }
+    }
+
+    fn build_query(query: &mut QueryParameters) {
+        query.include::<T>();
+    }
+}
+
+impl<'a> Fetch for EntityId {
+    fn fetch(e: EntityId, _w: &mut World) -> Self {
+        e
+    }
+
+    fn build_query(_query: &mut QueryParameters) {
+        // fetching entities in a query will not modify the parameters
+    }
+}
+
+fortuples! {
+    #[tuples::min_size(1)]
+    #[tuples::max_size(8)]
+    impl Fetch for #Tuple
+    where
+        #(#Member: Fetch),*
+    {
+        fn fetch(e: EntityId, w: &mut World) -> Self {
+            ( #(#Member::fetch(e, w)),* )
+        }
+
+        fn build_query(query: &mut QueryParameters) {
+            #(#Member::build_query(query));*
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::component::ComponentId;
+
+    #[test]
+    fn query_single() {
+        let mut w = World::new();
+        let val = 42u8;
+        let e = w.spawn();
+        w.insert(e, val);
+        let cid = ComponentId::from_val_type(&val);
+
+        let query_params = QueryParameters {
+            view: Layout::from(vec![cid]),
+        };
+
+        let query = Query::new(query_params);
+        let result = query.evaluate(&mut w);
+
+        assert_eq!(result.get_entities(), vec![e]);
+        assert_eq!(result.get_components::<u8>(), vec![val]);
+    }
+
+    #[test]
+    fn query_iter() {
+        let mut w = World::new();
+        let e = w.spawn();
+        let val1 = 360u32;
+        let val2 = 42u8;
+        w.insert(e, val1);
+        w.insert(e, val2);
+
+        let query = <(EntityId, &mut u32, &mut u8)>::query();
+        for (query_e, c1, c2) in query.iter_mut(&mut w) {
+            assert_eq!(e, query_e);
+            assert_eq!(*c1, val1);
+            assert_eq!(*c2, val2);
+
+            *c1 += *c2 as u32;
+        }
+
+        assert_eq!(w.get::<u32>(e).copied(), Some(val1 + val2 as u32));
+    }
+
+    #[test]
+    fn query_unmatched() {
+        let mut w = World::new();
+        let e = w.spawn();
+        let c = 360u32;
+        w.insert(e, c);
+
+        let query = <(EntityId, &mut u8)>::query();
+        for _ in query.iter_mut(&mut w) {
+            panic!("Entities unexpectedly matched query.");
+        }
+    }
+}


### PR DESCRIPTION
Adds the new ECS crate "dominion" and accompanying documentation.
- [x] add the initial crate and license it
- [ ] make dominion actually work with domains and not one big world
- [ ] add ECS design info to the design doc
- [ ] plan out steps of ECS development in roadmap
- [ ] check off write design document in roadmap
