### PR TITLE
`hearth-panels`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ hearth-network = { path = "crates/hearth-network" }
 hearth-rpc = { path = "crates/hearth-rpc" }
 hearth-types = { path = "crates/hearth-types" }
 hearth-wasm = { path = "crates/hearth-wasm" }
+serde_json = "1"
 tracing = "0.1.37"
 
 [workspace.dependencies.remoc]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "crates/hearth-guest",
   "crates/hearth-ipc",
   "crates/hearth-macros",
+  "crates/hearth-panels",
   "crates/hearth-network",
   "crates/hearth-rpc",
   "crates/hearth-server",

--- a/crates/hearth-client/Cargo.toml
+++ b/crates/hearth-client/Cargo.toml
@@ -10,6 +10,7 @@ hearth-cognito = { workspace = true }
 hearth-core = { workspace = true }
 hearth-ipc = { workspace = true }
 hearth-network = { workspace = true }
+hearth-panels = { path = "../hearth-panels" }
 hearth-rpc = { workspace = true }
 remoc = { workspace = true, features = ["full"] }
 tokio = { version = "1.24", features = ["full"] }

--- a/crates/hearth-client/src/main.rs
+++ b/crates/hearth-client/src/main.rs
@@ -119,6 +119,7 @@ async fn main() {
 
     let mut builder = RuntimeBuilder::new();
     builder.add_plugin(hearth_cognito::WasmPlugin::new());
+    builder.add_plugin(hearth_panels::PanelsPlugin::new());
 
     let runtime = builder.run(config);
     let peer_api = runtime.clone().serve_peer_api();

--- a/crates/hearth-core/src/lib.rs
+++ b/crates/hearth-core/src/lib.rs
@@ -18,6 +18,8 @@
 
 use tracing::{debug, error, info};
 
+pub use tokio;
+
 /// Asset loading and storage.
 pub mod asset;
 

--- a/crates/hearth-core/src/lib.rs
+++ b/crates/hearth-core/src/lib.rs
@@ -27,6 +27,9 @@ pub mod lump;
 /// Process interfaces and message routing.
 pub mod process;
 
+/// Publish-subscribe utility struct for making pub-sub services.
+pub mod pubsub;
+
 /// Peer runtime building and execution.
 pub mod runtime;
 

--- a/crates/hearth-core/src/lib.rs
+++ b/crates/hearth-core/src/lib.rs
@@ -19,6 +19,7 @@
 use tracing::{debug, error, info};
 
 pub use tokio;
+pub use tracing;
 
 /// Asset loading and storage.
 pub mod asset;

--- a/crates/hearth-core/src/pubsub.rs
+++ b/crates/hearth-core/src/pubsub.rs
@@ -1,0 +1,107 @@
+// Copyright (c) 2023 the Hearth contributors.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This file is part of Hearth.
+//
+// Hearth is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Affero General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// Hearth is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Hearth. If not, see <https://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+use std::fmt::Display;
+
+use hearth_rpc::hearth_types::ProcessId;
+use hearth_rpc::remoc::rtc::async_trait;
+use hearth_rpc::ProcessInfo;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tracing::error;
+
+use crate::process::{Message, Process, ProcessContext};
+
+/// A process that publishes events of type T to all subscribed processes.
+///
+/// To subscribe to this publisher, send a message containing `subscribe`. To
+/// unsubscribe, send `unsubscribe`. Messages with new events of type T will be
+/// formatted and sent to a subscriber until it unsubscribes.
+pub struct PublisherProcess<T> {
+    receiver: Receiver<T>,
+    subscribers: HashSet<ProcessId>,
+}
+
+#[async_trait]
+impl<T: Display + Send + Sync + 'static> Process for PublisherProcess<T> {
+    fn get_info(&self) -> ProcessInfo {
+        ProcessInfo {}
+    }
+
+    async fn run(&mut self, mut ctx: ProcessContext) {
+        loop {
+            tokio::select! {
+                message = ctx.recv() => {
+                    if let Some(message) = message {
+                        self.on_message(message);
+                    } else {
+                        break; // process is dead
+                    }
+                },
+                event = self.receiver.recv() => {
+                    if let Some(event) = event {
+                        self.on_event(&mut ctx, event).await;
+                    } else {
+                        break; // all senders are dropped; die
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<T: Display + Send + Sync + 'static> PublisherProcess<T> {
+    /// Creates a new [PublisherProcess] and a [Sender] to send events to it.
+    ///
+    /// When all senders are dropped, the process dies.
+    pub fn new() -> (Sender<T>, Self) {
+        let (sender, receiver) = channel(128);
+        let publisher = Self {
+            receiver,
+            subscribers: HashSet::new(),
+        };
+
+        (sender, publisher)
+    }
+
+    /// Internal message handling.
+    fn on_message(&mut self, message: Message) {
+        match message.data.as_slice() {
+            b"subscribe" => {
+                self.subscribers.insert(message.sender);
+            }
+            b"unsubscribe" => {
+                self.subscribers.remove(&message.sender);
+            }
+            _ => error!(
+                "Expected 'subscribe' or 'unsubscribe' from PID {:?}; received {:?}",
+                message.sender, message.data
+            ),
+        }
+    }
+
+    /// Internal event handling.
+    async fn on_event(&mut self, ctx: &mut ProcessContext, event: T) {
+        let event_data = event.to_string().into_bytes();
+        for subscriber in self.subscribers.iter() {
+            if let Err(err) = ctx.send_message(*subscriber, event_data.clone()).await {
+                error!("Event notification sending error: {:?}", err);
+            }
+        }
+    }
+}

--- a/crates/hearth-panels/Cargo.toml
+++ b/crates/hearth-panels/Cargo.toml
@@ -7,4 +7,5 @@ license = "AGPL-3.0-or-later"
 [dependencies]
 hearth-core = { workspace = true }
 hearth-rpc = { workspace = true }
+serde_json = { workspace = true }
 slab = "0.4.8"

--- a/crates/hearth-panels/Cargo.toml
+++ b/crates/hearth-panels/Cargo.toml
@@ -7,3 +7,4 @@ license = "AGPL-3.0-or-later"
 [dependencies]
 hearth-core = { workspace = true }
 hearth-rpc = { workspace = true }
+slab = "0.4.8"

--- a/crates/hearth-panels/Cargo.toml
+++ b/crates/hearth-panels/Cargo.toml
@@ -2,7 +2,8 @@
 name = "hearth-panels"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license = "AGPL-3.0-or-later"
 
 [dependencies]
+hearth-core = { workspace = true }
+hearth-rpc = { workspace = true }

--- a/crates/hearth-panels/Cargo.toml
+++ b/crates/hearth-panels/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "hearth-panels"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/hearth-panels/src/lib.rs
+++ b/crates/hearth-panels/src/lib.rs
@@ -1,14 +1,37 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+// Copyright (c) 2023 the Hearth contributors.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This file is part of Hearth.
+//
+// Hearth is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Affero General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// Hearth is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Hearth. If not, see <https://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use hearth_rpc::remoc::rtc::async_trait;
+use hearth_core::runtime::{Plugin, Runtime, RuntimeBuilder};
+
+pub struct PanelsPlugin {}
+
+#[async_trait]
+impl Plugin for PanelsPlugin {
+    fn build(&mut self, builder: &mut RuntimeBuilder) {}
+
+    async fn run(&mut self, runtime: Arc<Runtime>) {}
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+impl PanelsPlugin {
+    pub fn new() -> Self {
+        Self {}
     }
 }

--- a/crates/hearth-panels/src/lib.rs
+++ b/crates/hearth-panels/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/crates/hearth-panels/src/lib.rs
+++ b/crates/hearth-panels/src/lib.rs
@@ -18,14 +18,33 @@
 
 use std::sync::Arc;
 
-use hearth_rpc::remoc::rtc::async_trait;
+use hearth_core::process::{Process, ProcessContext};
+use hearth_core::pubsub::PublisherProcess;
 use hearth_core::runtime::{Plugin, Runtime, RuntimeBuilder};
+use hearth_core::tokio::sync::mpsc;
+use hearth_rpc::hearth_types::panels::*;
+use hearth_rpc::remoc::rtc::async_trait;
+use hearth_rpc::ProcessInfo;
+use slab::Slab;
 
+/// Plugin to add paneling support to a Hearth runtime.
+///
+/// Adds the [PanelControlService] and [AmbientPanelService] services.
 pub struct PanelsPlugin {}
 
 #[async_trait]
 impl Plugin for PanelsPlugin {
-    fn build(&mut self, builder: &mut RuntimeBuilder) {}
+    fn build(&mut self, builder: &mut RuntimeBuilder) {
+        builder.add_service(
+            "hearth.panels.PanelControlService".into(),
+            PanelControlService::new(),
+        );
+
+        /*builder.add_service(
+            "hearth.panels.AmbientPanelService".into(),
+            AmbientPanelService::new(),
+        );*/
+    }
 
     async fn run(&mut self, runtime: Arc<Runtime>) {}
 }
@@ -33,5 +52,137 @@ impl Plugin for PanelsPlugin {
 impl PanelsPlugin {
     pub fn new() -> Self {
         Self {}
+    }
+}
+
+/// `hearth.panels.PanelControlService`: Controls panels.
+pub struct PanelControlService {}
+
+#[async_trait]
+impl Process for PanelControlService {
+    fn get_info(&self) -> ProcessInfo {
+        ProcessInfo {}
+    }
+
+    async fn run(&mut self, mut ctx: ProcessContext) {
+        ctx.join().await;
+    }
+}
+
+impl PanelControlService {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+/// `hearth.panels.AmbientPanelService`: Publisher for panel events addressed
+/// to the ambient panel.
+pub type AmbientPanelService = PublisherProcess<PanelEvent>;
+
+/// Core data structure for panel management.
+pub struct PanelStore {
+    /// The pool of [PanelWrappers][PanelWrapper] to active panels.
+    pub panels: Slab<PanelWrapper>,
+
+    /// The currently focused panel.
+    pub focused: Option<usize>,
+}
+
+impl PanelStore {
+    /// Creates an empty [PanelStore].
+    pub fn new() -> Self {
+        Self {
+            panels: Default::default(),
+            focused: None,
+        }
+    }
+
+    /// Adds a new panel to the store. Returns its ID.
+    pub fn add_panel(&mut self, wrapper: PanelWrapper) -> usize {
+        self.panels.insert(wrapper)
+    }
+
+    /// Changes panel focus to a new panel.
+    ///
+    /// Returns the ID of the last focused panel. Does nothing and returns
+    /// `None` if the new panel ID is invalid.
+    pub fn focus(&mut self, panel: usize) -> Option<usize> {
+        if !self.panel_send(panel, PanelEvent::Focus(true)) {
+            return None;
+        }
+
+        if let Some(last) = self.focused.replace(panel) {
+            // self.focused should never point to an invalid panel
+            self.expect_send(last, PanelEvent::Focus(false));
+            Some(last)
+        } else {
+            None
+        }
+    }
+
+    /// Safely sends a panel event to a panel, returning true if successful.
+    fn panel_send(&mut self, panel: usize, message: PanelEvent) -> bool {
+        if let Some(wrapper) = self.panels.get(panel) {
+            let result = wrapper.event_tx.send(message);
+            if result.is_err() {
+                self.panels.remove(panel);
+                false // remote hung up
+            } else {
+                true // successfully sent the message
+            }
+        } else {
+            false // no panel was found
+        }
+    }
+
+    /// Gets a panel wrapper but panic if the ID was not found.
+    fn expect_panel(&self, panel: usize) -> &PanelWrapper {
+        match self.panels.get(panel) {
+            Some(wrapper) => wrapper,
+            None => panic!("Expected panel ID {} to be valid", panel),
+        }
+    }
+
+    /// Sends a message to a panel, returning true if successful, but panics if
+    /// the ID was not found.
+    fn expect_send(&mut self, panel: usize, message: PanelEvent) -> bool {
+        let result = self.expect_panel(panel).event_tx.send(message);
+        if result.is_err() {
+            self.panels.remove(panel);
+            false // remote hung up
+        } else {
+            true // successfully sent the message
+        }
+    }
+}
+
+/// Handle to a remote panel implementation.
+pub struct PanelWrapper {
+    /// The sender to send messages.
+    pub event_tx: mpsc::UnboundedSender<PanelEvent>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn add_passthru(store: &mut PanelStore) -> (usize, mpsc::UnboundedReceiver<PanelEvent>) {
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        let wrapper = PanelWrapper { event_tx };
+        let id = store.add_panel(wrapper);
+        (id, event_rx)
+    }
+
+    #[test]
+    fn focus() {
+        let mut store = PanelStore::new();
+        let (p1_id, mut p1_rx) = add_passthru(&mut store);
+        let (p2_id, mut p2_rx) = add_passthru(&mut store);
+        assert_eq!(store.focus(42), None);
+        assert_eq!(store.focus(p1_id), None);
+        assert_eq!(p1_rx.try_recv().unwrap(), PanelEvent::Focus(true));
+        assert_eq!(store.focus(p2_id), Some(p1_id));
+        assert_eq!(p1_rx.try_recv().unwrap(), PanelEvent::Focus(false));
+        assert_eq!(p2_rx.try_recv().unwrap(), PanelEvent::Focus(true));
     }
 }

--- a/crates/hearth-panels/src/lib.rs
+++ b/crates/hearth-panels/src/lib.rs
@@ -31,6 +31,10 @@ use tokio::sync::{mpsc, RwLock};
 /// Plugin to add paneling support to a Hearth runtime.
 ///
 /// Adds the [PanelControlService] and [AmbientPanelService] services.
+///
+/// To create panels in this store, use [Self::get_store] during plugin
+/// building to get access to the [PanelStore], then during runtime execution,
+/// call [PanelStore::add_panel] to add custom panels to the store.
 pub struct PanelsPlugin {
     store: Arc<RwLock<PanelStore>>,
 }
@@ -53,11 +57,17 @@ impl Plugin for PanelsPlugin {
 }
 
 impl PanelsPlugin {
+    /// Creates a new panel management plugin.
     pub fn new() -> Self {
         let store = PanelStore::new();
         let store = RwLock::new(store);
         let store = Arc::new(store);
         Self { store }
+    }
+
+    /// Retrieves the [PanelStore] this plugin will run.
+    pub fn get_store(&self) -> Arc<RwLock<PanelStore>> {
+        self.store.to_owned()
     }
 }
 

--- a/crates/hearth-types/Cargo.toml
+++ b/crates/hearth-types/Cargo.toml
@@ -6,3 +6,4 @@ license = "AGPL-3.0-or-later"
 
 [dependencies]
 serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/hearth-types/src/lib.rs
+++ b/crates/hearth-types/src/lib.rs
@@ -59,6 +59,18 @@ impl Display for LumpId {
     }
 }
 
+#[macro_export]
+macro_rules! impl_serialize_json_display {
+    ($ty: ident) => {
+        impl ::std::fmt::Display for $ty {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                let string = ::serde_json::to_string(self).map_err(|_| ::std::fmt::Error)?;
+                f.write_str(&string)
+            }
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/hearth-types/src/lib.rs
+++ b/crates/hearth-types/src/lib.rs
@@ -20,6 +20,9 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use serde::{Deserialize, Serialize};
 
+/// Paneling-related protocols and utilities.
+pub mod panels;
+
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ProcessId(pub u64);
 

--- a/crates/hearth-types/src/panels.rs
+++ b/crates/hearth-types/src/panels.rs
@@ -1,0 +1,38 @@
+// Copyright (c) 2023 the Hearth contributors.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This file is part of Hearth.
+//
+// Hearth is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Affero General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// Hearth is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Hearth. If not, see <https://www.gnu.org/licenses/>.
+
+use serde::{Deserialize, Serialize};
+
+/// A user input event.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub enum InputEvent {
+    /// The panel received a Unicode character.
+    ReceivedCharacter(char),
+}
+
+/// An event sent to a panel.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub enum PanelEvent {
+    /// The panel has gained focus (`true`) or lost focus (`false`).
+    Focus(bool),
+
+    /// The panel received an [InputEvent].
+    Input(InputEvent),
+}
+
+crate::impl_serialize_json_display!(PanelEvent);

--- a/crates/hearth-types/src/panels.rs
+++ b/crates/hearth-types/src/panels.rs
@@ -36,3 +36,10 @@ pub enum PanelEvent {
 }
 
 crate::impl_serialize_json_display!(PanelEvent);
+
+/// A message sent to the panel control service to control the panel store.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub enum PanelCommand {
+    /// Focuses a panel.
+    Focus(u32),
+}


### PR DESCRIPTION
Adds the new `hearth-panels` crate for panel management and an extendable panel store, plus some process utilities like `PublisherService` and `impl_serialize_json_display`. Touches up `hearth-core` with `tokio` and `tracing` repubs. Defines an initial protocol for the paneling processes.
