### PR TITLE
core: use non-sharded slab for processes

### DIFF
--- a/crates/hearth-core/Cargo.toml
+++ b/crates/hearth-core/Cargo.toml
@@ -13,6 +13,7 @@ hearth-ipc = { workspace = true }
 hearth-rpc = { workspace = true }
 serde = { workspace = true }
 sharded-slab = "0.1"
+slab = "0.4.8"
 tokio = { version = "1.24", features = ["full"] }
 toml = "0.7"
 tracing = { workspace = true }


### PR DESCRIPTION
Closes #73.

I couldn't duplicate this behavior in a unit test, but I managed to trace the issue to downcasting entry keys given by the `sharded-slab` crate from a 64-bit `usize` to a 32-bit `LocalProcessId`. `sharded-slab` stored page info in the high-order 32 bits of a 64-bit key and that was getting discarded. Since we don't want bits in higher orders for process IDs for the sake of human readability, I just bit the performance bullet and swapped out `sharded-slab` for the slightly slower `RwLock`'d `slab::Slab`.
