### PR TITLE
rpc: add `ProcessStatus`

### DIFF
--- a/crates/hearth-rpc/src/lib.rs
+++ b/crates/hearth-rpc/src/lib.rs
@@ -146,7 +146,7 @@ pub trait ProcessStore {
     /// This list is updated live as processes are spawned, killed, or changed.
     async fn follow_process_list(
         &self,
-    ) -> CallResult<HashMapSubscription<LocalProcessId, ProcessInfo>>;
+    ) -> CallResult<HashMapSubscription<LocalProcessId, ProcessStatus>>;
 
     /// Subscribes to this store's service list.
     ///
@@ -258,6 +258,22 @@ pub struct ProcessLogEvent {
     // TODO serializeable timestamp?
 }
 
-/// A process's metadata.
+/// User information about a process.
 #[derive(Clone, Debug, Hash, Deserialize, Serialize)]
 pub struct ProcessInfo {}
+
+/// The state of a currently running process.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ProcessStatus {
+    /// A live counter of the number of warnings that this process has logged.
+    pub warning_num: watch::Receiver<u32>,
+
+    /// A live counter of the number of errors that this process has logged.
+    pub error_num: watch::Receiver<u32>,
+
+    /// A live counter of the total number of log events that this process has logged.
+    pub log_num: watch::Receiver<u32>,
+
+    /// This process's user information.
+    pub info: ProcessInfo,
+}


### PR DESCRIPTION
Adding a `ProcessStatus` struct to help debug processes at runtime.

Also a necessary prerequisite for #56, since `hearth-ctl` needs to know the current length of the history in order to receive only the history in some modes.

- rpc: add ProcessStatus struct
- core: update process submodule to use ProcessStatus
