### PR TITLE
client: only enable winit x11 and wayland-dlopen features

### DIFF
--- a/crates/hearth-client/Cargo.toml
+++ b/crates/hearth-client/Cargo.toml
@@ -17,4 +17,8 @@ hearth-rpc = { workspace = true }
 remoc = { workspace = true, features = ["full"] }
 tokio = { version = "1.24", features = ["full"] }
 tracing = { workspace = true }
-winit = "0.27"
+
+[dependencies.winit]
+version = "0.27"
+default-features = false
+features = ["x11", "wayland-dlopen"]


### PR DESCRIPTION
Still needs testing to make sure that I didn't remove something essential.

Closes #111.
