### PR TITLE
WebAssembly spawning

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ component separately.
 - [x] implement IPC using Unix domain sockets (Unix only)
 - [ ] complete `hearth-ctl`
 - [ ] define guest-to-host WebAssembly APIs for logging, lump loading, and message transmission
-- [ ] create a native service for spawning WebAssembly processes
+- [x] create a native service for spawning WebAssembly processes
 - [x] integrate rend3 and winit into `hearth-client`
 
 ## Phase 2: Alpha

--- a/crates/hearth-client/src/main.rs
+++ b/crates/hearth-client/src/main.rs
@@ -168,7 +168,7 @@ async fn async_main(args: Args, rend3_plugin: Rend3Plugin) {
         .unwrap_or_else(|| hearth_core::get_config_path());
     let config_file = hearth_core::load_config(&config_path).unwrap();
 
-    let runtime = {
+    let (runtime, join_handles) = {
         // move into block to make this async fn Send
         let mut builder = RuntimeBuilder::new(config_file);
         builder.add_plugin(hearth_cognito::WasmPlugin::new());
@@ -211,5 +211,10 @@ async fn async_main(args: Args, rend3_plugin: Rend3Plugin) {
         _ = hearth_core::wait_for_interrupt() => {
             info!("Ctrl+C hit; quitting client");
         }
+    }
+
+    debug!("Aborting runners");
+    for join in join_handles {
+        join.abort();
     }
 }

--- a/crates/hearth-cognito/Cargo.toml
+++ b/crates/hearth-cognito/Cargo.toml
@@ -10,6 +10,7 @@ hearth-core = { workspace = true }
 hearth-macros = { workspace = true }
 hearth-rpc = { workspace = true }
 hearth-wasm = { workspace = true }
+serde_json = { workspace = true }
 slab = "0.4.8"
 tracing = { workspace = true }
 wasmtime = "5.0.0"

--- a/crates/hearth-core/src/process.rs
+++ b/crates/hearth-core/src/process.rs
@@ -156,6 +156,11 @@ impl ProcessContext {
         self.pid
     }
 
+    /// Gets this context's [ProcessStoreImpl].
+    pub fn get_process_store(&self) -> &Arc<ProcessStoreImpl> {
+        &self.process_store
+    }
+
     /// Returns true when this process is still alive.
     pub fn is_alive(&self) -> bool {
         *self.is_alive.borrow()

--- a/crates/hearth-ctl/src/spawn_wasm.rs
+++ b/crates/hearth-ctl/src/spawn_wasm.rs
@@ -69,5 +69,8 @@ impl SpawnWasm {
             })
             .await
             .unwrap();
+
+        // necessary to flush the message send; remove when waiting for the returned PID
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     }
 }

--- a/crates/hearth-server/src/main.rs
+++ b/crates/hearth-server/src/main.rs
@@ -87,7 +87,7 @@ async fn main() {
     let mut builder = RuntimeBuilder::new(config_file);
     builder.add_plugin(hearth_cognito::WasmPlugin::new());
 
-    let runtime = builder.run(config);
+    let (runtime, join_handles) = builder.run(config);
     let peer_api = runtime.clone().serve_peer_api();
     peer_provider
         .write()
@@ -124,7 +124,11 @@ async fn main() {
     }
     hearth_ipc::listen(daemon_listener, daemon_offer);
     hearth_core::wait_for_interrupt().await;
+
     info!("Interrupt received; exiting server");
+    for join in join_handles {
+        join.abort();
+    }
 }
 
 fn listen(


### PR DESCRIPTION
- `WasmProcessSpawner` receives `WasmSpawnInfo` messages and spawns `WasmProcess`s
- adds `ProcessContext::get_process_store()`
- add epoch-based yields to WebAssembly execution
- fixes an issue where `ctl`'s `spawn-wasm` command was not sending the message because it quits before the channel is flushed
- check off Wasm process spawning from roadmap
- return a Vec of `JoinHandle`s from `RuntimeBuilder::run()` so that runners and plugins can be aborted at the end of each binary