### PR TITLE
Multiple entrypoints + `this_lump()`

### DIFF
--- a/crates/hearth-ctl/src/spawn_wasm.rs
+++ b/crates/hearth-ctl/src/spawn_wasm.rs
@@ -59,7 +59,11 @@ impl SpawnWasm {
             )
             .await
             .unwrap();
-        let wasm_spawn_info = WasmSpawnInfo { lump: lump_id };
+
+        let wasm_spawn_info = WasmSpawnInfo {
+            lump: lump_id,
+            entrypoint: None,
+        };
 
         process
             .outgoing

--- a/crates/hearth-types/src/wasm.rs
+++ b/crates/hearth-types/src/wasm.rs
@@ -27,4 +27,8 @@ use serde::{Deserialize, Serialize};
 pub struct WasmSpawnInfo {
     /// The [LumpId] of the Wasm module lump source.
     pub lump: LumpId,
+
+    /// The identifier of the entrypoint to execute. If not specified, runs
+    /// the exported "run" function.
+    pub entrypoint: Option<u32>,
 }

--- a/guest/rust/hearth-guest/src/lib.rs
+++ b/guest/rust/hearth-guest/src/lib.rs
@@ -26,6 +26,13 @@ fn abi_string(str: &str) -> (u32, u32) {
     (ptr, len)
 }
 
+/// Fetches the lump ID of the module used to spawn the current process.
+pub fn this_lump() -> LumpId {
+    let mut id = LumpId(Default::default());
+    unsafe { abi::process::this_lump(&mut id as *const LumpId as u32) }
+    id
+}
+
 /// Fetches the process ID of the current process.
 pub fn this_pid() -> ProcessId {
     let pid = unsafe { abi::process::this_pid() };
@@ -249,6 +256,7 @@ mod abi {
     pub mod process {
         #[link(wasm_import_module = "hearth::process")]
         extern "C" {
+            pub fn this_lump(ptr: u32);
             pub fn this_pid() -> u64;
             pub fn kill(pid: u64);
         }

--- a/guest/rust/hearth-guest/src/lib.rs
+++ b/guest/rust/hearth-guest/src/lib.rs
@@ -271,3 +271,9 @@ mod abi {
         }
     }
 }
+
+#[no_mangle]
+extern "C" fn _hearth_spawn_by_index(function: u32) {
+    let function: fn() = unsafe { std::mem::transmute(function as usize) };
+    function();
+}

--- a/guest/rust/hearth-test-wasm/Cargo.toml
+++ b/guest/rust/hearth-test-wasm/Cargo.toml
@@ -8,3 +8,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 hearth-guest = { workspace = true }
+serde = { version = "1", features = ["derive"] }
+serde_json = { workspace = true }

--- a/guest/rust/hearth-test-wasm/src/lib.rs
+++ b/guest/rust/hearth-test-wasm/src/lib.rs
@@ -1,7 +1,99 @@
+use hearth_guest::{wasm::WasmSpawnInfo, LocalProcessId, ProcessId};
+
+fn get_spawner() -> ProcessId {
+    let this_peer = hearth_guest::this_pid().split().0;
+    hearth_guest::service_lookup(this_peer, "hearth.cognito.WasmProcessSpawner")
+        .expect("Couldn't find Wasm spawner service")
+}
+
+fn send<T: serde::Serialize>(pid: ProcessId, data: &T) {
+    let msg = serde_json::to_vec(data).unwrap();
+    hearth_guest::send(pid, &msg);
+}
+
+fn recv<T: for<'a> serde::Deserialize<'a>>() -> (ProcessId, T) {
+    let msg = hearth_guest::recv();
+    let sender = msg.get_sender();
+    let data = serde_json::from_slice(&msg.get_data()).unwrap();
+    (sender, data)
+}
+
+fn spawn(spawner: ProcessId, cb: fn()) -> ProcessId {
+    send(
+        spawner,
+        &WasmSpawnInfo {
+            lump: hearth_guest::this_lump(),
+            entrypoint: Some(unsafe { std::mem::transmute::<fn(), usize>(cb) } as u32),
+        },
+    );
+
+    let msg = String::from_utf8(hearth_guest::recv().get_data()).unwrap();
+    let local_pid: u32 = msg.parse().unwrap();
+    ProcessId::from_peer_process(spawner.split().0, LocalProcessId(local_pid))
+}
+
 #[no_mangle]
 pub extern "C" fn run() {
-    let this_peer = hearth_guest::this_pid().split().0;
-    let spawner = hearth_guest::service_lookup(this_peer, "hearth.cognito.WasmProcessSpawner")
-        .expect("Couldn't find Wasm spawner service");
-    hearth_guest::send(spawner, b"test message");
+    let spawner = get_spawner();
+    let input: Vec<u64> = (0..1000000).into_iter().rev().collect();
+
+    for _ in 0..100 {
+        let child = spawn(spawner, merge_sort_outer);
+        send(
+            child,
+            &Data {
+                inner: input.clone(),
+            },
+        );
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct Data {
+    pub inner: Vec<u64>,
+}
+
+fn bubble_sort(input: &mut Vec<u64>) {
+    let mut swapped = true;
+    while swapped {
+        swapped = false;
+        for idx in 0..(input.len() - 1) {
+            if input[idx] >= input[idx + 1] {
+                input.swap(idx, idx + 1);
+                swapped = true;
+            }
+        }
+    }
+}
+
+fn merge_sort_outer() {
+    let spawner = get_spawner();
+    let (parent, input) = recv::<Data>();
+    let result = merge_sort(spawner, input.inner);
+    send(parent, &Data { inner: result });
+}
+
+fn merge_sort(spawner: ProcessId, mut input: Vec<u64>) -> Vec<u64> {
+    if input.len() > 32 {
+        let a_pid = spawn(spawner, merge_sort_outer);
+        let b_pid = spawn(spawner, merge_sort_outer);
+
+        let (a, b) = input.split_at(input.len() / 2);
+        send(a_pid, &Data { inner: a.to_vec() });
+        send(b_pid, &Data { inner: b.to_vec() });
+
+        let (_sender, a_sorted) = recv::<Data>();
+        let (_sender, b_sorted) = recv::<Data>();
+        merge(a_sorted.inner, b_sorted.inner)
+    } else {
+        bubble_sort(&mut input);
+        input
+    }
+}
+
+fn merge(mut a: Vec<u64>, b: Vec<u64>) -> Vec<u64> {
+    // blech i can do this later
+    a.extend_from_slice(&b);
+    a.sort_unstable();
+    a
 }

--- a/guest/rust/hearth-test-wasm/src/lib.rs
+++ b/guest/rust/hearth-test-wasm/src/lib.rs
@@ -35,17 +35,8 @@ fn spawn(spawner: ProcessId, cb: fn()) -> ProcessId {
 #[no_mangle]
 pub extern "C" fn run() {
     let spawner = get_spawner();
-    let input: Vec<u64> = (0..1000000).into_iter().rev().collect();
-
-    for _ in 0..100 {
-        let child = spawn(spawner, merge_sort_outer);
-        send(
-            child,
-            &Data {
-                inner: input.clone(),
-            },
-        );
-    }
+    let input: Vec<u64> = (0..100000).into_iter().rev().collect();
+    merge_sort(spawner, input);
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
- adds the `entrypoint` field to `WasmSpawnInfo` so that multiple entrypoints can be called on a single Wasm module.
- adds the `process::this_lump()` ABI call so that processes can retrieve the lump IDs of the lumps that they were spawned with.
- updates the `hearth-test-wasm` crate with a modified recursive merge sort that switches to bubble sort on chunks smaller than 33 elements. this tests both the concurrency capabilities of Hearth and its message passing against a (relatively) compute-intensive parallel operation.