### PR TITLE
Basic init system API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "crates/hearth-ctl",
   "crates/hearth-cognito",
   "crates/hearth-core",
+  "crates/hearth-init",
   "crates/hearth-ipc",
   "crates/hearth-fs",
   "crates/hearth-macros",
@@ -21,6 +22,7 @@ members = [
 bytemuck = "1.13"
 hearth-cognito = { path = "crates/hearth-cognito" }
 hearth-core = { path = "crates/hearth-core" }
+hearth-init = { path = "crates/hearth-init" }
 hearth-ipc = { path = "crates/hearth-ipc" }
 hearth-fs = { path = "crates/hearth-fs" }
 hearth-macros = { path = "crates/hearth-macros" }

--- a/crates/hearth-client/Cargo.toml
+++ b/crates/hearth-client/Cargo.toml
@@ -9,6 +9,7 @@ glam = "0.20"
 clap = { version= "3.2", features = ["derive"] }
 hearth-cognito = { workspace = true }
 hearth-core = { workspace = true }
+hearth-init = { workspace = true }
 hearth-ipc = { workspace = true }
 hearth-network = { workspace = true }
 hearth-rend3 = { workspace = true }

--- a/crates/hearth-core/src/process/mod.rs
+++ b/crates/hearth-core/src/process/mod.rs
@@ -39,6 +39,9 @@ pub type ProcessFactory = factory::ProcessFactory<ProcessStore>;
 /// The default local process using [ProcessStore].
 pub type Process = factory::Process<ProcessStore>;
 
+/// The default connection using [ProcessStore].
+pub type Connection = remote::Connection<ProcessStore>;
+
 #[derive(Default)]
 pub struct AnyProcessData {
     pub local: <LocalProcess as ProcessEntry>::Data,

--- a/crates/hearth-init/Cargo.toml
+++ b/crates/hearth-init/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "hearth-init"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+hearth-core = { workspace = true }
+tracing = { workspace = true }

--- a/crates/hearth-init/src/lib.rs
+++ b/crates/hearth-init/src/lib.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2023 the Hearth contributors.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This file is part of Hearth.
+//
+// Hearth is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Affero General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// Hearth is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Hearth. If not, see <https://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use hearth_core::{
+    async_trait,
+    hearth_types::Flags,
+    process::{context::ContextSignal, factory::ProcessInfo, Process},
+    runtime::{Plugin, Runtime, RuntimeBuilder},
+    tokio::{spawn, sync::oneshot::Sender},
+};
+
+struct Hook {
+    service: String,
+    callback: Sender<(Process, usize)>,
+}
+
+pub struct InitPlugin {
+    hooks: Vec<Hook>,
+}
+
+#[async_trait]
+impl Plugin for InitPlugin {
+    fn build(&mut self, builder: &mut RuntimeBuilder) {
+        for hook in std::mem::take(&mut self.hooks) {
+            builder.add_service(
+                hook.service,
+                ProcessInfo {},
+                Flags::SEND,
+                move |_runtime, mut ctx| {
+                    spawn(async move {
+                        while let Some(signal) = ctx.recv().await {
+                            let ContextSignal::Message(msg) = signal else {
+                                tracing::error!("expected message, got {:?}", signal);
+                                continue;
+                            };
+
+                            let Some(init_cap) = msg.caps.first() else {
+                                continue;
+                            };
+
+                            let _ = hook.callback.send((ctx, *init_cap));
+                            break;
+                        }
+                    });
+                },
+            );
+        }
+    }
+
+    async fn run(&mut self, runtime: Arc<Runtime>) {}
+}
+
+impl InitPlugin {
+    pub fn new() -> Self {
+        Self { hooks: Vec::new() }
+    }
+
+    pub fn add_hook(&mut self, service: String, callback: Sender<(Process, usize)>) {
+        self.hooks.push(Hook { service, callback });
+    }
+}

--- a/crates/hearth-server/Cargo.toml
+++ b/crates/hearth-server/Cargo.toml
@@ -8,6 +8,7 @@ license = "AGPL-3.0-or-later"
 clap = { version = "3.2", features = ["derive"] }
 hearth-cognito = { workspace = true }
 hearth-core = { workspace = true }
+hearth-init = { workspace = true }
 hearth-ipc = { workspace = true }
 hearth-fs = { workspace = true }
 hearth-network = { workspace = true }

--- a/crates/hearth-server/src/main.rs
+++ b/crates/hearth-server/src/main.rs
@@ -82,7 +82,7 @@ async fn main() {
 
     let (network_root_tx, network_root_rx) = oneshot::channel();
     let mut init = hearth_init::InitPlugin::new();
-    init.add_hook("hearth.server.NetworkHook".into(), network_root_tx);
+    init.add_hook("hearth.init.Server".into(), network_root_tx);
 
     let mut builder = RuntimeBuilder::new(config_file);
     builder.add_plugin(hearth_cognito::WasmPlugin::new());


### PR DESCRIPTION
Adds the `hearth-init` crate, hooks, and makes server networking and client networking depend on the init system to provide root capabilities for each of their connections.