### PR TITLE
Refactor plugins API

### DIFF
--- a/crates/hearth-client/src/main.rs
+++ b/crates/hearth-client/src/main.rs
@@ -120,7 +120,7 @@ async fn async_main(args: Args, rend3_plugin: Rend3Plugin) {
     builder.add_plugin(hearth_fs::FsPlugin::new(args.root));
     builder.add_plugin(rend3_plugin);
     builder.add_plugin(init);
-    let (runtime, join_handles) = builder.run(config).await;
+    let runtime = builder.run(config).await;
 
     tokio::spawn(async move {
         connect(network_root_rx, runtime, args.server, args.password).await;
@@ -139,11 +139,6 @@ async fn async_main(args: Args, rend3_plugin: Rend3Plugin) {
 
     hearth_core::wait_for_interrupt().await;
     info!("Ctrl+C hit; quitting client");
-
-    debug!("Aborting runners");
-    for join in join_handles {
-        join.abort();
-    }
 }
 
 async fn connect(

--- a/crates/hearth-cognito/examples/run_wasm.rs
+++ b/crates/hearth-cognito/examples/run_wasm.rs
@@ -22,7 +22,7 @@ async fn main() {
     let config_file = hearth_core::load_config(&config_path).unwrap();
     let mut builder = RuntimeBuilder::new(config_file);
     builder.add_plugin(hearth_cognito::WasmPlugin::new());
-    let (runtime, join_handles) = builder.run(config).await;
+    let runtime = builder.run(config).await;
 
     let wasm_lump = runtime.lump_store.add_lump(wasm_data.into()).await;
     let spawn_info = WasmSpawnInfo {
@@ -49,7 +49,4 @@ async fn main() {
     hearth_core::wait_for_interrupt().await;
 
     info!("Interrupt received; exiting runtime");
-    for join in join_handles {
-        join.abort();
-    }
 }

--- a/crates/hearth-core/src/runtime.rs
+++ b/crates/hearth-core/src/runtime.rs
@@ -24,13 +24,11 @@
 
 use std::any::{Any, TypeId};
 use std::collections::{HashMap, HashSet};
-use std::future::Future;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use hearth_types::{Flags, PeerId};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
-use tokio::task::JoinHandle;
 use tracing::{debug, error, warn};
 
 use crate::asset::{AssetLoader, AssetStore};
@@ -40,27 +38,30 @@ use crate::process::factory::ProcessInfo;
 /// Interface trait for plugins to the Hearth runtime.
 ///
 /// Each plugin first builds onto a runtime using its `build` function and an
-/// in-progress [RuntimeBuilder]. After all plugins are added, the runtime
-/// starts, and the `run` method is called with a handle to the new runtime.
+/// in-progress [RuntimeBuilder]. During this phase, plugins can mutably access
+/// other plugins that have already been added. When all the plugins have been
+/// added, the final phase of runtime building begins. Each plugin's `run`
+/// method takes ownership of the plugin and finishes adding onto the
+/// [RuntimeBuilder] using the complete configuration for that plugin.
 #[async_trait]
-pub trait Plugin: Send + Sync + 'static {
+pub trait Plugin: Sized + Send + Sync + 'static {
     /// Builds a runtime using this plugin. See [RuntimeBuilder] for more info.
-    fn build(&mut self, builder: &mut RuntimeBuilder);
+    fn build(&mut self, _builder: &mut RuntimeBuilder) {}
 
-    /// Runs this plugin using an instantiated [Runtime].
-    async fn run(&mut self, runtime: Arc<Runtime>);
+    /// Finishes building this runtime before the runtime starts. See [RuntimeBuilder] for more info.
+    fn finish(self, _builder: &mut RuntimeBuilder) {}
 }
 
 struct PluginWrapper {
     plugin: Box<dyn Any + Send>,
-    runner: Box<dyn FnOnce(Box<dyn Any>, Arc<Runtime>) -> JoinHandle<()> + Send>,
+    finish: Box<dyn FnOnce(Box<dyn Any>, &mut RuntimeBuilder) + Send>,
 }
 
 /// Builder struct for a single Hearth [Runtime].
 pub struct RuntimeBuilder {
     config_file: toml::Table,
     plugins: HashMap<TypeId, PluginWrapper>,
-    runners: Vec<Box<dyn FnOnce(Arc<Runtime>) -> JoinHandle<()> + Send>>,
+    runners: Vec<Box<dyn FnOnce(Arc<Runtime>) + Send>>,
     services: HashSet<String>,
     lump_store: Arc<LumpStoreImpl>,
     asset_store: AssetStore,
@@ -105,7 +106,11 @@ impl RuntimeBuilder {
     /// Adds a plugin to the runtime.
     ///
     /// Plugins may use their [Plugin::build] method to add other plugins,
-    /// asset loaders, runners, or anything else.
+    /// asset loaders, runners, or anything else. Then, plugins may configure
+    /// already-added plugins using [RuntimeBuilder::get_plugin] and
+    /// [RuntimeBuilder::get_plugin_mut]. After all plugins have been added
+    /// and before the runtime is started, [Plugin::finish] is called with
+    /// each plugin to complete the plugin's building.
     pub fn add_plugin<T: Plugin>(&mut self, mut plugin: T) -> &mut Self {
         let name = std::any::type_name::<T>();
         debug!("Adding {} plugin", name);
@@ -122,12 +127,10 @@ impl RuntimeBuilder {
             id,
             PluginWrapper {
                 plugin: Box::new(plugin),
-                runner: Box::new(move |plugin, runtime| {
-                    let mut plugin = plugin.downcast::<T>().unwrap();
-                    tokio::spawn(async move {
-                        debug!("Running {} plugin", name);
-                        plugin.run(runtime).await;
-                    })
+                finish: Box::new(move |plugin, builder| {
+                    let plugin = plugin.downcast::<T>().unwrap();
+                    debug!("Finishing {} plugin", name);
+                    plugin.finish(builder);
                 }),
             },
         );
@@ -137,21 +140,15 @@ impl RuntimeBuilder {
 
     /// Adds a runner to the runtime.
     ///
-    /// Runners are simple async functions that are spawned when the runtime is
-    /// started and are passed a handle to the new runtime. This may be used
-    /// for long-running event processing code or other functionality that
-    /// lasts the runtime's lifetime.
-    pub fn add_runner<F, R>(&mut self, cb: F) -> &mut Self
+    /// Runners are functions that are spawned when the runtime is started and
+    /// are passed a handle to the new runtime. This may be used to spawn tasks
+    /// to handle long-running event processing code or other functionality
+    /// that lasts the runtime's lifetime.
+    pub fn add_runner<F>(&mut self, cb: F) -> &mut Self
     where
-        F: FnOnce(Arc<Runtime>) -> R + Send + Sync + 'static,
-        R: Future<Output = ()> + Send,
+        F: FnOnce(Arc<Runtime>) + Send + 'static,
     {
-        self.runners.push(Box::new(|runner| {
-            tokio::spawn(async move {
-                cb(runner).await;
-            })
-        }));
-
+        self.runners.push(Box::new(cb));
         self
     }
 
@@ -177,7 +174,7 @@ impl RuntimeBuilder {
         self.service_num += 1;
 
         self.services.insert(name.clone());
-        self.runners.push(Box::new(move |runtime| {
+        self.add_runner(move |runtime| {
             tokio::spawn(async move {
                 debug!("Spawning '{}' service", name);
                 let process = runtime.process_factory.spawn(info, flags);
@@ -193,8 +190,8 @@ impl RuntimeBuilder {
                 let _ = service_start_tx.send(name);
 
                 cb(runtime, process);
-            })
-        }));
+            });
+        });
 
         self
     }
@@ -231,9 +228,22 @@ impl RuntimeBuilder {
 
     /// Consumes this builder and starts up the full [Runtime].
     ///
-    /// This returns a shared pointer to the new runtime, as well as all of the
-    /// [JoinHandles][JoinHandle] for the launched runners and plugins.
-    pub async fn run(self, config: RuntimeConfig) -> (Arc<Runtime>, Vec<JoinHandle<()>>) {
+    /// This returns a shared pointer to the new runtime.
+    pub async fn run(mut self, config: RuntimeConfig) -> Arc<Runtime> {
+        debug!("Finishing plugins");
+        loop {
+            let plugins = std::mem::take(&mut self.plugins);
+
+            if plugins.is_empty() {
+                break;
+            }
+
+            for (_id, wrapper) in plugins {
+                let PluginWrapper { plugin, finish } = wrapper;
+                finish(plugin, &mut self);
+            }
+        }
+
         use crate::process::*;
 
         let process_store = Arc::new(ProcessStore::default());
@@ -255,19 +265,9 @@ impl RuntimeBuilder {
             config,
         });
 
-        let mut join_handles = Vec::new();
-
-        debug!("Running plugins");
-        for (_id, wrapper) in self.plugins {
-            let PluginWrapper { plugin, runner } = wrapper;
-            let join = runner(plugin, runtime.clone());
-            join_handles.push(join);
-        }
-
         debug!("Running runners");
         for runner in self.runners {
-            let join = runner(runtime.clone());
-            join_handles.push(join);
+            runner(runtime.clone());
         }
 
         let service_num = self.service_num;
@@ -284,7 +284,7 @@ impl RuntimeBuilder {
 
         debug!("All services started");
 
-        (runtime, join_handles)
+        runtime
     }
 }
 

--- a/crates/hearth-fs/src/lib.rs
+++ b/crates/hearth-fs/src/lib.rs
@@ -102,8 +102,8 @@ impl FsPlugin {
     async fn serve(&self, mut ctx: Process, lumps: Arc<LumpStoreImpl>) {
         while let Some(signal) = ctx.recv().await {
             let ContextSignal::Message(message) = signal else {
-            panic!("expected message signal; got {:?}", signal);
-        };
+                panic!("expected message signal; got {:?}", signal);
+            };
 
             // TODO share this code with hearth-cognito in hearth-core
             let request: Request = match serde_json::from_slice(&message.data) {
@@ -124,8 +124,8 @@ impl FsPlugin {
             let response = on_request(&self.root, request, lumps.as_ref()).await;
             let response = serde_json::to_vec(&response).unwrap();
             let Some(reply) = message.caps.first().copied() else {
-            continue;
-        };
+                continue;
+            };
 
             ctx.send(
                 reply,

--- a/crates/hearth-fs/src/lib.rs
+++ b/crates/hearth-fs/src/lib.rs
@@ -22,7 +22,6 @@ use std::{
 };
 
 use hearth_core::{
-    async_trait,
     hearth_types::{fs::*, Flags, ProcessLogLevel},
     lump::LumpStoreImpl,
     process::{
@@ -30,52 +29,9 @@ use hearth_core::{
         factory::{ProcessInfo, ProcessLogEvent},
         Process,
     },
-    runtime::{Plugin, Runtime, RuntimeBuilder},
+    runtime::{Plugin, RuntimeBuilder},
     tracing::warn,
 };
-
-async fn serve(root: PathBuf, mut ctx: Process, lumps: Arc<LumpStoreImpl>) {
-    while let Some(signal) = ctx.recv().await {
-        let ContextSignal::Message(message) = signal else {
-            panic!("expected message signal; got {:?}", signal);
-        };
-
-        // TODO share this code with hearth-cognito in hearth-core
-        let request: Request = match serde_json::from_slice(&message.data) {
-            Ok(message) => message,
-            Err(err) => {
-                ctx.log(ProcessLogEvent {
-                    level: ProcessLogLevel::Error,
-                    module: "WasmProcessSpawner".to_string(),
-                    content: format!("Failed to parse WasmSpawnInfo: {:?}", err),
-                });
-
-                warn!("Failed to parse WasmSpawnInfo: {:?}", err);
-
-                continue;
-            }
-        };
-
-        let response = on_request(&root, request, lumps.as_ref()).await;
-        let response = serde_json::to_vec(&response).unwrap();
-        let Some(reply) = message.caps.first().copied() else {
-            continue;
-        };
-
-        ctx.send(
-            reply,
-            ContextMessage {
-                data: response,
-                caps: vec![],
-            },
-        )
-        .unwrap();
-
-        for unused in message.caps {
-            ctx.delete_capability(unused).unwrap();
-        }
-    }
-}
 
 async fn on_request(root: &Path, request: Request, lumps: &LumpStoreImpl) -> Response {
     let target = PathBuf::try_from(request.target).map_err(|_| Error::InvalidTarget)?;
@@ -123,28 +79,66 @@ pub struct FsPlugin {
     root: PathBuf,
 }
 
-#[async_trait]
 impl Plugin for FsPlugin {
-    fn build(&mut self, builder: &mut RuntimeBuilder) {
-        let root = self.root.clone();
-
+    fn finish(self, builder: &mut RuntimeBuilder) {
         builder.add_service(
             "hearth.fs.Filesystem".into(),
             ProcessInfo {},
             Flags::SEND,
             move |runtime, process| {
                 hearth_core::tokio::spawn(async move {
-                    serve(root, process, runtime.lump_store.clone()).await;
+                    self.serve(process, runtime.lump_store.clone()).await;
                 });
             },
         );
     }
-
-    async fn run(&mut self, _runtime: Arc<Runtime>) {}
 }
 
 impl FsPlugin {
     pub fn new(root: PathBuf) -> Self {
         Self { root }
+    }
+
+    async fn serve(&self, mut ctx: Process, lumps: Arc<LumpStoreImpl>) {
+        while let Some(signal) = ctx.recv().await {
+            let ContextSignal::Message(message) = signal else {
+            panic!("expected message signal; got {:?}", signal);
+        };
+
+            // TODO share this code with hearth-cognito in hearth-core
+            let request: Request = match serde_json::from_slice(&message.data) {
+                Ok(message) => message,
+                Err(err) => {
+                    ctx.log(ProcessLogEvent {
+                        level: ProcessLogLevel::Error,
+                        module: "WasmProcessSpawner".to_string(),
+                        content: format!("Failed to parse WasmSpawnInfo: {:?}", err),
+                    });
+
+                    warn!("Failed to parse WasmSpawnInfo: {:?}", err);
+
+                    continue;
+                }
+            };
+
+            let response = on_request(&self.root, request, lumps.as_ref()).await;
+            let response = serde_json::to_vec(&response).unwrap();
+            let Some(reply) = message.caps.first().copied() else {
+            continue;
+        };
+
+            ctx.send(
+                reply,
+                ContextMessage {
+                    data: response,
+                    caps: vec![],
+                },
+            )
+            .unwrap();
+
+            for unused in message.caps {
+                ctx.delete_capability(unused).unwrap();
+            }
+        }
     }
 }

--- a/crates/hearth-rend3/src/lib.rs
+++ b/crates/hearth-rend3/src/lib.rs
@@ -18,8 +18,7 @@
 
 use std::sync::Arc;
 
-use hearth_core::async_trait;
-use hearth_core::runtime::{Plugin, Runtime, RuntimeBuilder};
+use hearth_core::runtime::{Plugin, RuntimeBuilder};
 use rend3::graph::RenderGraph;
 use rend3::types::{Camera, SampleCount};
 use rend3::util::output::OutputFrame;
@@ -63,14 +62,13 @@ pub struct Rend3Plugin {
     pub frame_request_tx: mpsc::UnboundedSender<FrameRequest>,
 }
 
-#[async_trait]
 impl Plugin for Rend3Plugin {
-    fn build(&mut self, _builder: &mut RuntimeBuilder) {}
-
-    async fn run(&mut self, _runtime: Arc<Runtime>) {
-        while let Some(frame) = self.frame_request_rx.recv().await {
-            self.draw(frame);
-        }
+    fn finish(mut self, _builder: &mut RuntimeBuilder) {
+        tokio::spawn(async move {
+            while let Some(frame) = self.frame_request_rx.recv().await {
+                self.draw(frame);
+            }
+        });
     }
 }
 

--- a/crates/hearth-server/src/main.rs
+++ b/crates/hearth-server/src/main.rs
@@ -84,7 +84,7 @@ async fn main() {
     builder.add_plugin(hearth_cognito::WasmPlugin::new());
     builder.add_plugin(hearth_fs::FsPlugin::new(args.root));
     builder.add_plugin(init);
-    let (runtime, join_handles) = builder.run(config).await;
+    let runtime = builder.run(config).await;
 
     debug!("Initializing IPC");
     let daemon_listener = match hearth_ipc::Listener::new().await {
@@ -107,9 +107,6 @@ async fn main() {
     hearth_core::wait_for_interrupt().await;
 
     info!("Interrupt received; exiting server");
-    for join in join_handles {
-        join.abort();
-    }
 }
 
 async fn bind(


### PR DESCRIPTION
The `Plugin` trait had some non-useful semantics, namely the `run` method,
which was virtually never used. I've replaced it with the `finish` method,
which takes ownership of the plugin and gives it a `RuntimeBuilder` to finalize
the building of a plugin after it's been configured by other plugins.
