### PR TITLE
alacritty: use system shell instead of fish

### DIFF
--- a/crates/rend3-alacritty/examples/demo.rs
+++ b/crates/rend3-alacritty/examples/demo.rs
@@ -69,6 +69,17 @@ impl DemoInner {
         let mut colors = Colors::default();
         Self::load_colors(&mut colors);
 
+        let command: String = match std::env::consts::OS {
+            "dragonfly" | "freebsd" | "haiku" | "linux" | "macos" | "netbsd" | "openbsd"
+            | "redox" | "solaris" | "unix" => {
+                std::env::var("SHELL").expect("Couldn't get system shell: `$SHELL` not set. ")
+            }
+            "windows" => {
+                std::env::var("COMSPEC").expect("Couldn't get system shell: `%COMSPEC%` not set. ")
+            }
+            _ => todo!(),
+        };
+
         let state = TerminalState {
             position: glam::Vec3::ZERO,
             orientation: glam::Quat::IDENTITY,
@@ -76,7 +87,11 @@ impl DemoInner {
             opacity: 0.8,
         };
 
-        let config = TerminalConfig { fonts, colors };
+        let config = TerminalConfig {
+            fonts,
+            colors,
+            command,
+        };
         let terminal = Terminal::new(config.clone(), state.clone());
         let mut store = TerminalStore::new(config, renderer, surface_format);
         store.insert_terminal(&terminal);

--- a/crates/rend3-alacritty/src/terminal.rs
+++ b/crates/rend3-alacritty/src/terminal.rs
@@ -71,6 +71,7 @@ impl EventListener for Listener {
 pub struct TerminalConfig {
     pub fonts: FontSet<Arc<FaceAtlas>>,
     pub colors: Colors,
+    pub command: String,
 }
 
 /// Dynamic terminal appearance and settings configuration.
@@ -145,7 +146,7 @@ impl Terminal {
 
         let (sender, term_events) = channel();
 
-        let shell = alacritty_terminal::config::Program::Just("/usr/bin/fish".into());
+        let shell = alacritty_terminal::config::Program::Just(config.command.clone().into());
 
         let term_config = alacritty_terminal::config::Config {
             pty_config: PtyConfig {


### PR DESCRIPTION
Closes #70.


Notes on Windows:
There is no environment variable for the user's preferred shell program, so it's best to just grab one of the two standard system shells (cmd and PowerShell). I feel that PowerShell would be preferable, but given the lack of a standard environment variable pointing to its location, cmd is used instead. 