### PR TITLE
Alacritty improvements

### DIFF
--- a/crates/rend3-alacritty/Cargo.toml
+++ b/crates/rend3-alacritty/Cargo.toml
@@ -9,6 +9,7 @@ alacritty_terminal = "0.16"
 bytemuck = { version = "1.13", features = ["derive"] }
 font-mud = { path = "../font-mud" }
 glam = "0.20"
+mio-extras = "2"
 owned_ttf_parser = "0.18.1"
 rend3 = "0.3"
 rend3-routine = "0.3"
@@ -17,5 +18,4 @@ wgpu = "^0.12"
 [dev-dependencies]
 image = "0.24"
 rend3-framework = "0.3"
-mio-extras = "2"
 winit = "0.26"

--- a/crates/rend3-alacritty/examples/demo.rs
+++ b/crates/rend3-alacritty/examples/demo.rs
@@ -77,7 +77,8 @@ impl DemoInner {
             colors,
         };
 
-        let config = TerminalConfig { fonts };
+        let command = None; // autoselect shell
+        let config = TerminalConfig { fonts, command };
         let terminal = Terminal::new(config.clone(), state.clone());
         let mut store = TerminalStore::new(config, renderer, surface_format);
         store.insert_terminal(&terminal);

--- a/crates/rend3-alacritty/examples/demo.rs
+++ b/crates/rend3-alacritty/examples/demo.rs
@@ -73,6 +73,7 @@ impl DemoInner {
             position: glam::Vec3::ZERO,
             orientation: glam::Quat::IDENTITY,
             half_size: Vec2::new(1.2, 0.9),
+            opacity: 0.8,
         };
 
         let config = TerminalConfig { fonts, colors };

--- a/crates/rend3-alacritty/examples/demo.rs
+++ b/crates/rend3-alacritty/examples/demo.rs
@@ -74,9 +74,10 @@ impl DemoInner {
             orientation: glam::Quat::IDENTITY,
             half_size: Vec2::new(1.2, 0.9),
             opacity: 0.8,
+            colors,
         };
 
-        let config = TerminalConfig { fonts, colors };
+        let config = TerminalConfig { fonts };
         let terminal = Terminal::new(config.clone(), state.clone());
         let mut store = TerminalStore::new(config, renderer, surface_format);
         store.insert_terminal(&terminal);

--- a/crates/rend3-alacritty/src/gpu.rs
+++ b/crates/rend3-alacritty/src/gpu.rs
@@ -1,0 +1,133 @@
+// Copyright (c) 2023 the Hearth contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::marker::PhantomData;
+
+use bytemuck::{Pod, Zeroable};
+use wgpu::{util::DeviceExt, *};
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+pub struct CameraUniform {
+    pub mvp: glam::Mat4,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+pub struct SolidVertex {
+    pub position: glam::Vec2,
+    pub color: u32,
+}
+
+impl SolidVertex {
+    pub const LAYOUT: VertexBufferLayout<'static> = VertexBufferLayout {
+        array_stride: std::mem::size_of::<Self>() as BufferAddress,
+        step_mode: VertexStepMode::Vertex,
+        attributes: &[
+            VertexAttribute {
+                offset: 0,
+                format: VertexFormat::Float32x2,
+                shader_location: 0,
+            },
+            VertexAttribute {
+                offset: std::mem::size_of::<[f32; 2]>() as BufferAddress,
+                format: VertexFormat::Unorm8x4,
+                shader_location: 1,
+            },
+        ],
+    };
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+pub struct GlyphVertex {
+    pub position: glam::Vec2,
+    pub tex_coords: glam::Vec2,
+    pub color: u32,
+}
+
+impl GlyphVertex {
+    pub const LAYOUT: VertexBufferLayout<'static> = VertexBufferLayout {
+        array_stride: std::mem::size_of::<Self>() as BufferAddress,
+        step_mode: VertexStepMode::Vertex,
+        attributes: &[
+            VertexAttribute {
+                offset: 0,
+                format: VertexFormat::Float32x2,
+                shader_location: 0,
+            },
+            VertexAttribute {
+                offset: std::mem::size_of::<[f32; 2]>() as BufferAddress,
+                format: VertexFormat::Float32x2,
+                shader_location: 1,
+            },
+            VertexAttribute {
+                offset: std::mem::size_of::<[f32; 4]>() as BufferAddress,
+                format: VertexFormat::Unorm8x4,
+                shader_location: 2,
+            },
+        ],
+    };
+}
+
+pub struct DynamicMesh<T> {
+    vertex_buffer: Buffer,
+    index_buffer: Buffer,
+    index_num: u32,
+    _data: PhantomData<T>,
+}
+
+impl<T: Pod> DynamicMesh<T> {
+    pub fn new(device: &Device) -> Self {
+        Self {
+            vertex_buffer: device.create_buffer(&BufferDescriptor {
+                label: Some("AlacrittyRoutine vertex buffer"),
+                size: 0,
+                mapped_at_creation: false,
+                usage: BufferUsages::VERTEX,
+            }),
+            index_buffer: device.create_buffer(&BufferDescriptor {
+                label: Some("AlacrittyRoutine vertex buffer"),
+                size: 0,
+                mapped_at_creation: false,
+                usage: BufferUsages::INDEX,
+            }),
+            index_num: 0,
+            _data: PhantomData,
+        }
+    }
+
+    pub fn update(&mut self, device: &Device, vertices: &[T], indices: &[u32]) {
+        self.vertex_buffer = device.create_buffer_init(&util::BufferInitDescriptor {
+            label: Some("AlacrittyRoutine vertex buffer"),
+            contents: bytemuck::cast_slice(vertices),
+            usage: BufferUsages::VERTEX,
+        });
+
+        self.index_buffer = device.create_buffer_init(&util::BufferInitDescriptor {
+            label: Some("AlacrittyRoutine index buffer"),
+            contents: bytemuck::cast_slice(indices),
+            usage: BufferUsages::INDEX,
+        });
+
+        self.index_num = indices.len() as u32;
+    }
+
+    pub fn draw<'a>(&'a self, rpass: &mut RenderPass<'a>) {
+        rpass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+        rpass.set_index_buffer(self.index_buffer.slice(..), IndexFormat::Uint32);
+        rpass.draw_indexed(0..self.index_num, 0, 0..1);
+    }
+}

--- a/crates/rend3-alacritty/src/lib.rs
+++ b/crates/rend3-alacritty/src/lib.rs
@@ -266,7 +266,7 @@ impl TerminalStore {
         terminal: &'a TerminalDrawState,
         vp: glam::Mat4,
     ) {
-        let model = glam::Mat4::IDENTITY;
+        let model = terminal.model;
 
         self.queue.write_buffer(
             &terminal.camera_buffer,

--- a/crates/rend3-alacritty/src/lib.rs
+++ b/crates/rend3-alacritty/src/lib.rs
@@ -13,590 +13,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
-use std::marker::PhantomData;
-use std::ops::Deref;
-use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, Weak};
+use std::sync::{Arc, Weak};
 
-use alacritty_terminal::ansi::{Color, CursorShape, NamedColor};
-use alacritty_terminal::term::cell::Flags as CellFlags;
-use alacritty_terminal::term::color::{Colors, Rgb, COUNT};
-use alacritty_terminal::Term;
-use bytemuck::{Pod, Zeroable};
-use font_mud::glyph_atlas::GlyphAtlas;
-use owned_ttf_parser::{AsFaceRef, OwnedFace};
 use rend3::graph::{
     RenderGraph, RenderPassDepthTarget, RenderPassTarget, RenderPassTargets, RenderTargetHandle,
 };
 use rend3::Renderer;
-use wgpu::util::DeviceExt;
+
+use terminal::TerminalDrawState;
 use wgpu::*;
 
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Pod, Zeroable)]
-pub struct CameraUniform {
-    pub mvp: glam::Mat4,
-}
+/// Terminal-related logic and helpers.
+pub mod terminal;
 
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Pod, Zeroable)]
-pub struct SolidVertex {
-    pub position: glam::Vec2,
-    pub color: u32,
-}
+/// Text management.
+pub mod text;
 
-impl SolidVertex {
-    pub const LAYOUT: VertexBufferLayout<'static> = VertexBufferLayout {
-        array_stride: std::mem::size_of::<Self>() as BufferAddress,
-        step_mode: VertexStepMode::Vertex,
-        attributes: &[
-            VertexAttribute {
-                offset: 0,
-                format: VertexFormat::Float32x2,
-                shader_location: 0,
-            },
-            VertexAttribute {
-                offset: std::mem::size_of::<[f32; 2]>() as BufferAddress,
-                format: VertexFormat::Unorm8x4,
-                shader_location: 1,
-            },
-        ],
-    };
-}
+/// GPU-side logic and helpers.
+pub mod gpu;
 
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Pod, Zeroable)]
-pub struct GlyphVertex {
-    pub position: glam::Vec2,
-    pub tex_coords: glam::Vec2,
-    pub color: u32,
-}
-
-impl GlyphVertex {
-    pub const LAYOUT: VertexBufferLayout<'static> = VertexBufferLayout {
-        array_stride: std::mem::size_of::<Self>() as BufferAddress,
-        step_mode: VertexStepMode::Vertex,
-        attributes: &[
-            VertexAttribute {
-                offset: 0,
-                format: VertexFormat::Float32x2,
-                shader_location: 0,
-            },
-            VertexAttribute {
-                offset: std::mem::size_of::<[f32; 2]>() as BufferAddress,
-                format: VertexFormat::Float32x2,
-                shader_location: 1,
-            },
-            VertexAttribute {
-                offset: std::mem::size_of::<[f32; 4]>() as BufferAddress,
-                format: VertexFormat::Unorm8x4,
-                shader_location: 2,
-            },
-        ],
-    };
-}
-
-struct DynamicMesh<T> {
-    vertex_buffer: Buffer,
-    index_buffer: Buffer,
-    index_num: u32,
-    _data: PhantomData<T>,
-}
-
-impl<T: Pod> DynamicMesh<T> {
-    pub fn new(device: &Device) -> Self {
-        Self {
-            vertex_buffer: device.create_buffer(&BufferDescriptor {
-                label: Some("AlacrittyRoutine vertex buffer"),
-                size: 0,
-                mapped_at_creation: false,
-                usage: BufferUsages::VERTEX,
-            }),
-            index_buffer: device.create_buffer(&BufferDescriptor {
-                label: Some("AlacrittyRoutine vertex buffer"),
-                size: 0,
-                mapped_at_creation: false,
-                usage: BufferUsages::INDEX,
-            }),
-            index_num: 0,
-            _data: PhantomData,
-        }
-    }
-
-    pub fn update(&mut self, device: &Device, vertices: &[T], indices: &[u32]) {
-        self.vertex_buffer = device.create_buffer_init(&util::BufferInitDescriptor {
-            label: Some("AlacrittyRoutine vertex buffer"),
-            contents: bytemuck::cast_slice(vertices),
-            usage: BufferUsages::VERTEX,
-        });
-
-        self.index_buffer = device.create_buffer_init(&util::BufferInitDescriptor {
-            label: Some("AlacrittyRoutine index buffer"),
-            contents: bytemuck::cast_slice(indices),
-            usage: BufferUsages::INDEX,
-        });
-
-        self.index_num = indices.len() as u32;
-    }
-
-    pub fn draw<'a>(&'a self, rpass: &mut RenderPass<'a>) {
-        rpass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
-        rpass.set_index_buffer(self.index_buffer.slice(..), IndexFormat::Uint32);
-        rpass.draw_indexed(0..self.index_num, 0, 0..1);
-    }
-}
-
-/// A font face and its MSDF glyph atlas.
-pub struct FaceAtlas {
-    pub face: OwnedFace,
-    pub atlas: GlyphAtlas,
-    pub texture: Texture,
-    pub queue: Arc<Queue>,
-    pub touched: Mutex<HashSet<u16>>,
-}
-
-impl FaceAtlas {
-    /// Create a new atlas from a face. Note that this takes time to complete.
-    pub fn new(face: OwnedFace, device: &Device, queue: Arc<Queue>) -> Self {
-        let (atlas, _errors) = GlyphAtlas::new(face.as_face_ref()).unwrap();
-
-        let size = Extent3d {
-            width: atlas.width,
-            height: atlas.height,
-            depth_or_array_layers: 1,
-        };
-
-        let texture = device.create_texture_with_data(
-            &queue,
-            &TextureDescriptor {
-                label: Some("AlacrittyRoutine::glyph_texture"),
-                size,
-                mip_level_count: 1,
-                sample_count: 1,
-                dimension: TextureDimension::D2,
-                format: TextureFormat::Rgba8Unorm,
-                usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
-            },
-            &vec![0u8; (atlas.width * atlas.height * 4) as usize],
-        );
-
-        Self {
-            face,
-            atlas,
-            texture,
-            queue,
-            touched: Default::default(),
-        }
-    }
-
-    /// Generate and upload a glyph bitmap for each glyph that hasn't already been.
-    pub fn touch(&self, glyphs: &[u16]) {
-        let mut touched = self.touched.lock().unwrap();
-        for glyph in glyphs {
-            if touched.insert(*glyph) {
-                let glyph = self.atlas.glyphs.get(*glyph as usize);
-                let Some(Some(glyph)) = glyph else { continue };
-                let bitmap = glyph.shape.generate();
-
-                self.queue.write_texture(
-                    ImageCopyTexture {
-                        texture: &self.texture,
-                        mip_level: 0,
-                        origin: Origin3d {
-                            x: glyph.position.x,
-                            y: glyph.position.y,
-                            z: 0,
-                        },
-                        aspect: TextureAspect::All,
-                    },
-                    bitmap.data_bytes(),
-                    ImageDataLayout {
-                        offset: 0,
-                        bytes_per_row: std::num::NonZeroU32::new(glyph.size.x * 4),
-                        rows_per_image: std::num::NonZeroU32::new(glyph.size.y),
-                    },
-                    Extent3d {
-                        width: glyph.size.x,
-                        height: glyph.size.y,
-                        depth_or_array_layers: 1,
-                    },
-                );
-            }
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum FontStyle {
-    Regular,
-    Italic,
-    Bold,
-    BoldItalic,
-}
-
-impl FontStyle {
-    pub fn from_cell_flags(flags: CellFlags) -> Self {
-        if flags.contains(CellFlags::BOLD_ITALIC) {
-            Self::BoldItalic
-        } else if flags.contains(CellFlags::ITALIC) {
-            Self::Italic
-        } else if flags.contains(CellFlags::BOLD) {
-            Self::Bold
-        } else {
-            Self::Regular
-        }
-    }
-}
-
-/// Generic container for all font faces used in a terminal. Eases
-/// the writing of code manipulating all faces at once.
-#[derive(Clone, Debug, Default)]
-pub struct FontSet<T> {
-    pub regular: T,
-    pub italic: T,
-    pub bold: T,
-    pub bold_italic: T,
-}
-
-impl<T> FontSet<T> {
-    pub fn map<O>(self, f: impl Fn(T) -> O) -> FontSet<O> {
-        FontSet {
-            regular: f(self.regular),
-            italic: f(self.italic),
-            bold: f(self.bold),
-            bold_italic: f(self.bold_italic),
-        }
-    }
-
-    pub fn for_each(self, mut f: impl FnMut(T)) {
-        f(self.regular);
-        f(self.italic);
-        f(self.bold);
-        f(self.bold_italic);
-    }
-
-    pub fn get(&self, style: FontStyle) -> &T {
-        match style {
-            FontStyle::Regular => &self.regular,
-            FontStyle::Italic => &self.italic,
-            FontStyle::Bold => &self.bold,
-            FontStyle::BoldItalic => &self.bold_italic,
-        }
-    }
-
-    pub fn get_mut(&mut self, style: FontStyle) -> &mut T {
-        match style {
-            FontStyle::Regular => &mut self.regular,
-            FontStyle::Italic => &mut self.italic,
-            FontStyle::Bold => &mut self.bold,
-            FontStyle::BoldItalic => &mut self.bold_italic,
-        }
-    }
-
-    pub fn zip<O>(self, other: FontSet<O>) -> FontSet<(T, O)> {
-        FontSet {
-            regular: (self.regular, other.regular),
-            italic: (self.italic, other.italic),
-            bold: (self.bold, other.bold),
-            bold_italic: (self.bold_italic, other.bold_italic),
-        }
-    }
-
-    pub fn as_ref(&self) -> FontSet<&T> {
-        FontSet {
-            regular: &self.regular,
-            italic: &self.italic,
-            bold: &self.bold,
-            bold_italic: &self.bold_italic,
-        }
-    }
-
-    pub fn as_mut(&mut self) -> FontSet<&mut T> {
-        FontSet {
-            regular: &mut self.regular,
-            italic: &mut self.italic,
-            bold: &mut self.bold,
-            bold_italic: &mut self.bold_italic,
-        }
-    }
-}
-
-/// CPU-side terminal rendering options.
-pub struct TerminalConfig {
-    pub fonts: FontSet<Arc<FaceAtlas>>,
-}
-
-/// A single render-able terminal. Paired with an [AlacrittyRoutine].
-pub struct Terminal {
-    device: Arc<Device>,
-    config: Arc<TerminalConfig>,
-    camera_buffer: Buffer,
-    camera_bind_group: BindGroup,
-    bg_mesh: DynamicMesh<SolidVertex>,
-    glyph_meshes: FontSet<DynamicMesh<GlyphVertex>>,
-    overlay_mesh: DynamicMesh<SolidVertex>,
-}
-
-impl Terminal {
-    pub fn new(
-        device: Arc<Device>,
-        config: Arc<TerminalConfig>,
-        camera_bgl: &BindGroupLayout,
-    ) -> Self {
-        let camera_buffer = device.create_buffer(&BufferDescriptor {
-            label: Some("Alacritty terminal camera buffer"),
-            size: std::mem::size_of::<CameraUniform>() as BufferAddress,
-            usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-
-        let camera_bind_group = device.create_bind_group(&BindGroupDescriptor {
-            label: Some("Alacritty terminal camera bind group"),
-            layout: camera_bgl,
-            entries: &[BindGroupEntry {
-                binding: 0,
-                resource: camera_buffer.as_entire_binding(),
-            }],
-        });
-
-        Self {
-            config,
-            camera_buffer,
-            camera_bind_group,
-            bg_mesh: DynamicMesh::new(&device),
-            glyph_meshes: FontSet {
-                regular: DynamicMesh::new(&device),
-                italic: DynamicMesh::new(&device),
-                bold: DynamicMesh::new(&device),
-                bold_italic: DynamicMesh::new(&device),
-            },
-            overlay_mesh: DynamicMesh::new(&device),
-            device,
-        }
-    }
-
-    pub fn update<T: alacritty_terminal::event::EventListener>(
-        &mut self,
-        term: &Term<T>,
-        colors: &Colors,
-    ) {
-        let mut cells: Vec<(glam::Vec2, FontStyle, usize, u32)> = Vec::new();
-
-        let content = term.renderable_content();
-
-        let mut colors = colors.clone();
-        for idx in 0..COUNT {
-            if let Some(color) = content.colors[idx] {
-                colors[idx] = Some(color);
-            }
-        }
-
-        let color_to_rgb = |color| -> u32 {
-            let rgb = match color {
-                Color::Named(name) => colors[name].unwrap(),
-                Color::Spec(rgb) => rgb,
-                Color::Indexed(index) => {
-                    if let Some(color) = colors[index as usize] {
-                        color
-                    } else if let Some(gray) = index.checked_sub(232) {
-                        let value = gray * 10 + 8;
-                        Rgb {
-                            r: value,
-                            g: value,
-                            b: value,
-                        }
-                    } else if let Some(cube_idx) = index.checked_sub(16) {
-                        let r = cube_idx / 36;
-                        let g = (cube_idx / 6) % 6;
-                        let b = cube_idx % 6;
-
-                        let c = |c| {
-                            if c == 0 {
-                                0
-                            } else {
-                                c * 40 + 55
-                            }
-                        };
-
-                        Rgb {
-                            r: c(r),
-                            g: c(g),
-                            b: c(b),
-                        }
-                    } else {
-                        Rgb {
-                            r: 0xff,
-                            g: 0x00,
-                            b: 0xff,
-                        }
-                    }
-                }
-            };
-
-            0xff000000 | ((rgb.b as u32) << 16) | ((rgb.g as u32) << 8) | (rgb.r as u32)
-        };
-
-        let scale = 1.0 / 37.5;
-        let grid_to_pos = |x: i32, y: i32| -> glam::Vec2 {
-            let col = x as f32 / 50.0 - 1.0;
-            let row = (y as f32 + 1.0) / -37.5 + 1.0;
-            glam::Vec2::new(col, row)
-        };
-
-        let mut bg_vertices = Vec::new();
-        let mut bg_indices = Vec::new();
-        let mut overlay_vertices = Vec::new();
-        let mut overlay_indices = Vec::new();
-
-        
-        for cell in content.display_iter {
-            if cell.flags.contains(CellFlags::HIDDEN) {
-                continue;
-            }
-
-            let col = cell.point.column.0 as i32;
-            let row = cell.point.line.0;
-            let pos = grid_to_pos(col, row);
-            let mut fg = cell.fg;
-            let mut bg = cell.bg;
-
-            let is_full_block = cell.c == '▀';
-
-            if cell.flags.contains(CellFlags::INVERSE) ^ is_full_block {
-                std::mem::swap(&mut fg, &mut bg);
-            }
-
-            if !is_full_block {
-                let style = FontStyle::from_cell_flags(cell.flags);
-                let face = self.config.fonts.get(style).face.as_face_ref();
-                if let Some(glyph) = face.glyph_index(cell.c) {
-                    cells.push((pos, style, glyph.0 as usize, color_to_rgb(fg)));
-                }
-            }
-
-            if bg == Color::Named(NamedColor::Background) {
-                continue;
-            }
-
-            let bg = color_to_rgb(bg);
-            let index = bg_vertices.len() as u32;
-
-            bg_vertices.extend_from_slice(&[
-                SolidVertex {
-                    position: grid_to_pos(col, row - 1),
-                    color: bg,
-                },
-                SolidVertex {
-                    position: grid_to_pos(col + 1, row - 1),
-                    color: bg,
-                },
-                SolidVertex {
-                    position: grid_to_pos(col, row),
-                    color: bg,
-                },
-                SolidVertex {
-                    position: grid_to_pos(col + 1, row),
-                    color: bg,
-                },
-            ]);
-
-            bg_indices.extend_from_slice(&[
-                index,
-                index + 1,
-                index + 2,
-                index + 2,
-                index + 1,
-                index + 3,
-            ]);
-        }
-
-        let cursor_color = Color::Named(NamedColor::Foreground);
-        let cursor_color = color_to_rgb(cursor_color);
-        match content.cursor.shape {
-            CursorShape::Hidden => {}
-            _ => {
-                let index = overlay_vertices.len() as u32;
-                let col = content.cursor.point.column.0 as i32;
-                let row = content.cursor.point.line.0;
-                overlay_vertices.extend_from_slice(&[
-                    SolidVertex {
-                        position: grid_to_pos(col, row - 1),
-                        color: cursor_color,
-                    },
-                    SolidVertex {
-                        position: grid_to_pos(col + 1, row - 1),
-                        color: cursor_color,
-                    },
-                    SolidVertex {
-                        position: grid_to_pos(col, row),
-                        color: cursor_color,
-                    },
-                    SolidVertex {
-                        position: grid_to_pos(col + 1, row),
-                        color: cursor_color,
-                    },
-                ]);
-
-                overlay_indices.extend_from_slice(&[
-                    index,
-                    index + 1,
-                    index + 2,
-                    index + 2,
-                    index + 1,
-                    index + 3,
-                ]);
-            }
-        }
-
-        let mut touched = FontSet::<Vec<u16>>::default();
-        let mut glyph_meshes = FontSet::<(Vec<GlyphVertex>, Vec<u32>)>::default();
-
-        for (offset, style, glyph, color) in cells {
-            let (vertices, indices) = &mut glyph_meshes.get_mut(style);
-
-            let index = vertices.len() as u32;
-            let atlas = &self.config.fonts.get(style).atlas;
-            let bitmap = match atlas.glyphs[glyph].as_ref() {
-                Some(b) => b,
-                None => continue,
-            };
-
-            touched.get_mut(style).push(glyph as u16);
-
-            vertices.extend(bitmap.vertices.iter().map(|v| GlyphVertex {
-                position: v.position * scale + offset,
-                tex_coords: v.tex_coords,
-                color,
-            }));
-
-            indices.extend_from_slice(&[
-                index,
-                index + 1,
-                index + 2,
-                index + 2,
-                index + 1,
-                index + 3,
-            ]);
-        }
-
-        self.config
-            .fonts
-            .as_ref()
-            .zip(touched)
-            .for_each(|(font, touched)| {
-                font.touch(&touched);
-            });
-
-        self.glyph_meshes
-            .as_mut()
-            .zip(glyph_meshes)
-            .for_each(|(mesh, (vertices, indices))| mesh.update(&self.device, &vertices, &indices));
-
-        self.bg_mesh.update(&self.device, &bg_vertices, &bg_indices);
-        self.overlay_mesh
-            .update(&self.device, &overlay_vertices, &overlay_indices);
-    }
-}
+use crate::{
+    gpu::{CameraUniform, GlyphVertex, SolidVertex},
+    terminal::{Terminal, TerminalConfig},
+    text::FontSet,
+};
 
 /// Generates a pipeline for either a glyph shader or a solid shader.
 fn make_pipeline(
@@ -647,23 +87,37 @@ fn make_pipeline(
     })
 }
 
+pub struct TerminalWrapper {
+    terminal: Weak<Terminal>,
+    draw_state: TerminalDrawState,
+}
+
+impl TerminalWrapper {
+    pub fn update(&mut self) -> bool {
+        if let Some(terminal) = self.terminal.upgrade() {
+            terminal.update_draw_state(&mut self.draw_state);
+            true
+        } else {
+            false
+        }
+    }
+}
+
 /// Persistent terminal rendering configuration and handles to active terminals.
 pub struct TerminalStore {
     device: Arc<Device>,
     queue: Arc<Queue>,
-    config: Arc<TerminalConfig>,
     camera_bgl: BindGroupLayout,
     glyph_bind_groups: FontSet<BindGroup>,
     solid_pipeline: RenderPipeline,
     glyph_pipeline: RenderPipeline,
-    terminals: Vec<Weak<RwLock<Terminal>>>,
-    owned_terminals: Vec<Arc<RwLock<Terminal>>>,
+    terminals: Vec<TerminalWrapper>,
 }
 
 impl TerminalStore {
     /// This routine runs after tonemapping, so `format` is the format of the
     /// final swapchain image format.
-    pub fn new(config: Arc<TerminalConfig>, renderer: &Renderer, format: TextureFormat) -> Self {
+    pub fn new(config: TerminalConfig, renderer: &Renderer, format: TextureFormat) -> Self {
         let shader = renderer
             .device
             .create_shader_module(&include_wgsl!("shaders.wgsl"));
@@ -772,28 +226,22 @@ impl TerminalStore {
         Self {
             device: renderer.device.to_owned(),
             queue: renderer.queue.to_owned(),
-            config,
             camera_bgl,
             glyph_bind_groups,
             solid_pipeline,
             glyph_pipeline,
             terminals: vec![],
-            owned_terminals: vec![],
         }
     }
 
-    /// Creates a new terminal associated with this store.
+    /// Inserts a new terminal into this store.
     ///
-    /// When the last `Arc` is dropped, this terminal will stop being rendered.
-    pub fn create_terminal(&mut self) -> Arc<RwLock<Terminal>> {
-        let terminal = Arc::new(RwLock::new(Terminal::new(
-            self.device.to_owned(),
-            self.config.to_owned(),
-            &self.camera_bgl,
-        )));
-
-        self.terminals.push(Arc::downgrade(&terminal));
-        terminal
+    /// When the last `Arc` owning this terminal is dropped, this terminal will stop being rendered.
+    pub fn insert_terminal(&mut self, terminal: &Arc<Terminal>) {
+        self.terminals.push(TerminalWrapper {
+            terminal: Arc::downgrade(terminal),
+            draw_state: TerminalDrawState::new(self.device.to_owned(), &self.camera_bgl),
+        });
     }
 
     /// Creates a new render routine for this frame.
@@ -801,23 +249,9 @@ impl TerminalStore {
     /// Note that this locks the mutexes on all owned terminals for as long as
     /// this routine is owned. Create and then drop as quickly as possible!
     pub fn create_routine(&mut self) -> TerminalRenderRoutine<'_> {
-        self.owned_terminals.clear();
+        self.terminals.retain_mut(TerminalWrapper::update);
 
-        let mut index = 0;
-        while let Some(terminal) = self.terminals.get(index) {
-            if let Some(terminal) = terminal.upgrade() {
-                self.owned_terminals.push(terminal);
-                index += 1;
-            } else {
-                self.terminals.remove(index);
-            }
-        }
-
-        let terminals = self
-            .owned_terminals
-            .iter()
-            .map(|term| term.read().unwrap())
-            .collect();
+        let terminals: Vec<_> = self.terminals.iter().map(|t| &t.draw_state).collect();
 
         TerminalRenderRoutine {
             store: self,
@@ -829,7 +263,7 @@ impl TerminalStore {
     pub fn draw_terminal<'a>(
         &'a self,
         rpass: &mut RenderPass<'a>,
-        terminal: &'a Terminal,
+        terminal: &'a TerminalDrawState,
         vp: glam::Mat4,
     ) {
         let model = glam::Mat4::IDENTITY;
@@ -859,7 +293,7 @@ impl TerminalStore {
 
 pub struct TerminalRenderRoutine<'a> {
     store: &'a TerminalStore,
-    terminals: Vec<RwLockReadGuard<'a, Terminal>>,
+    terminals: Vec<&'a TerminalDrawState>,
 }
 
 impl<'a> TerminalRenderRoutine<'a> {
@@ -890,7 +324,7 @@ impl<'a> TerminalRenderRoutine<'a> {
         let terminals: Vec<_> = self
             .terminals
             .iter()
-            .map(|t| builder.passthrough_ref(t.deref()))
+            .map(|t| builder.passthrough_ref(*t))
             .collect();
 
         builder.build(

--- a/crates/rend3-alacritty/src/terminal.rs
+++ b/crates/rend3-alacritty/src/terminal.rs
@@ -1,0 +1,448 @@
+// Copyright (c) 2023 the Hearth contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::{channel, Sender},
+        Arc,
+    },
+    thread::JoinHandle,
+};
+
+use alacritty_terminal::{
+    ansi::{Color, CursorShape, NamedColor},
+    config::PtyConfig,
+    event::{Event, EventListener},
+    event_loop::{EventLoop, Msg, State},
+    grid::Indexed,
+    sync::FairMutex,
+    term::{
+        cell::{Cell, Flags},
+        color::{Colors, Rgb, COUNT},
+        RenderableContent, RenderableCursor,
+    },
+    tty::Pty,
+    Term,
+};
+use glam::Vec2;
+use mio_extras::channel::Sender as MioSender;
+use owned_ttf_parser::AsFaceRef;
+use wgpu::{
+    self, BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayout, Buffer, BufferAddress,
+    BufferDescriptor, BufferUsages, Device,
+};
+
+use crate::{
+    gpu::{CameraUniform, DynamicMesh, GlyphVertex, SolidVertex},
+    text::{FaceAtlas, FontSet, FontStyle},
+};
+
+pub struct Listener {
+    sender: Sender<Event>,
+}
+
+impl Listener {
+    pub fn new(sender: Sender<Event>) -> Self {
+        Self { sender }
+    }
+}
+
+impl EventListener for Listener {
+    fn send_event(&self, event: Event) {
+        self.sender.send(event).unwrap();
+    }
+}
+
+/// Configuration for the initialization of a terminal.
+#[derive(Clone)]
+pub struct TerminalConfig {
+    pub fonts: FontSet<Arc<FaceAtlas>>,
+    pub colors: Colors,
+}
+
+/// A CPU-side wrapper around terminal functionality.
+pub struct Terminal {
+    config: TerminalConfig,
+    term: Arc<FairMutex<Term<Listener>>>,
+    _term_loop: JoinHandle<(EventLoop<Pty, Listener>, State)>,
+    term_channel: Arc<FairMutex<MioSender<Msg>>>,
+    should_quit: AtomicBool,
+}
+
+impl Terminal {
+    pub fn new(config: TerminalConfig) -> Arc<Self> {
+        let term_size =
+            alacritty_terminal::term::SizeInfo::new(100.0, 75.0, 1.0, 1.0, 0.0, 0.0, false);
+
+        let (sender, term_events) = channel();
+
+        let shell = alacritty_terminal::config::Program::Just("/usr/bin/fish".into());
+
+        let term_config = alacritty_terminal::config::Config {
+            pty_config: PtyConfig {
+                shell: Some(shell),
+                working_directory: None,
+                hold: false,
+            },
+            ..Default::default()
+        };
+
+        let term_listener = Listener::new(sender.clone());
+
+        let term = Term::new(&term_config, term_size, term_listener);
+        let term = FairMutex::new(term);
+        let term = Arc::new(term);
+
+        let pty = alacritty_terminal::tty::new(&term_config.pty_config, &term_size, None).unwrap();
+
+        let term_listener = Listener::new(sender);
+        let term_loop = EventLoop::new(term.clone(), term_listener, pty, false, false);
+        let term_channel = term_loop.channel();
+
+        let term = Self {
+            config,
+            term,
+            _term_loop: term_loop.spawn(),
+            term_channel: Arc::new(FairMutex::new(term_channel)),
+            should_quit: AtomicBool::new(false),
+        };
+
+        let term = Arc::new(term);
+
+        let event_term = term.to_owned();
+        std::thread::spawn(move || {
+            while let Ok(event) = term_events.recv() {
+                event_term.on_event(event);
+            }
+        });
+
+        term
+    }
+
+    pub fn update_draw_state(&self, draw: &mut TerminalDrawState) {
+        let colors = self.config.colors.clone();
+        let mut canvas = TerminalCanvas::new(colors, self.config.fonts.clone());
+        let term = self.term.lock();
+        let content = term.renderable_content();
+        canvas.update_from_content(content);
+        drop(term); // get off the mutex
+        canvas.apply_to_state(draw);
+    }
+
+    pub fn should_quit(&self) -> bool {
+        self.should_quit.load(Ordering::Relaxed)
+    }
+
+    pub fn send_input(&self, input: &str) {
+        let bytes = input.as_bytes();
+        let cow = std::borrow::Cow::Owned(bytes.to_owned());
+        let sender = self.term_channel.lock();
+        sender.send(Msg::Input(cow)).unwrap();
+    }
+
+    fn on_event(&self, event: Event) {
+        match event {
+            Event::ColorRequest(index, format) => {
+                let color = self.config.colors[index].unwrap_or(Rgb {
+                    r: 0xff,
+                    g: 0xff,
+                    b: 0xff,
+                });
+
+                self.send_input(&format(color));
+            }
+            Event::PtyWrite(text) => self.send_input(&text),
+            Event::Exit => self.should_quit.store(true, Ordering::Relaxed),
+            _ => {}
+        }
+    }
+}
+
+/// A ready-to-render terminal state.
+pub struct TerminalDrawState {
+    pub device: Arc<Device>,
+    pub camera_buffer: Buffer,
+    pub camera_bind_group: BindGroup,
+    pub bg_mesh: DynamicMesh<SolidVertex>,
+    pub glyph_meshes: FontSet<DynamicMesh<GlyphVertex>>,
+    pub overlay_mesh: DynamicMesh<SolidVertex>,
+}
+
+impl TerminalDrawState {
+    pub fn new(device: Arc<Device>, camera_bgl: &BindGroupLayout) -> Self {
+        let camera_buffer = device.create_buffer(&BufferDescriptor {
+            label: Some("Alacritty terminal camera buffer"),
+            size: std::mem::size_of::<CameraUniform>() as BufferAddress,
+            usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let camera_bind_group = device.create_bind_group(&BindGroupDescriptor {
+            label: Some("Alacritty terminal camera bind group"),
+            layout: camera_bgl,
+            entries: &[BindGroupEntry {
+                binding: 0,
+                resource: camera_buffer.as_entire_binding(),
+            }],
+        });
+
+        Self {
+            camera_buffer,
+            camera_bind_group,
+            bg_mesh: DynamicMesh::new(&device),
+            glyph_meshes: FontSet {
+                regular: DynamicMesh::new(&device),
+                italic: DynamicMesh::new(&device),
+                bold: DynamicMesh::new(&device),
+                bold_italic: DynamicMesh::new(&device),
+            },
+            overlay_mesh: DynamicMesh::new(&device),
+            device,
+        }
+    }
+}
+
+/// An in-progress terminal draw state.
+pub struct TerminalCanvas {
+    colors: Colors,
+    fonts: FontSet<Arc<FaceAtlas>>,
+    bg_vertices: Vec<SolidVertex>,
+    bg_indices: Vec<u32>,
+    overlay_vertices: Vec<SolidVertex>,
+    overlay_indices: Vec<u32>,
+    glyphs: Vec<(Vec2, FontStyle, u16, u32)>,
+}
+
+impl TerminalCanvas {
+    pub fn new(colors: Colors, fonts: FontSet<Arc<FaceAtlas>>) -> Self {
+        Self {
+            colors,
+            fonts,
+            bg_vertices: Vec::new(),
+            bg_indices: Vec::new(),
+            overlay_vertices: Vec::new(),
+            overlay_indices: Vec::new(),
+            glyphs: Vec::new(),
+        }
+    }
+
+    pub fn update_from_content(&mut self, content: RenderableContent) {
+        for index in 0..COUNT {
+            if let Some(color) = content.colors[index] {
+                self.colors[index] = Some(color);
+            }
+        }
+
+        for cell in content.display_iter {
+            self.draw_cell(cell);
+        }
+
+        self.draw_cursor(content.cursor);
+    }
+
+    pub fn apply_to_state(&self, state: &mut TerminalDrawState) {
+        let mut touched = FontSet::<Vec<u16>>::default();
+        let mut glyph_meshes = FontSet::<(Vec<GlyphVertex>, Vec<u32>)>::default();
+
+        let scale = 1.0 / 37.5;
+        for (offset, style, glyph, color) in self.glyphs.iter().copied() {
+            let (vertices, indices) = &mut glyph_meshes.get_mut(style);
+
+            let index = vertices.len() as u32;
+            let atlas = &self.fonts.get(style).atlas;
+            let bitmap = match atlas.glyphs[glyph as usize].as_ref() {
+                Some(b) => b,
+                None => continue,
+            };
+
+            touched.get_mut(style).push(glyph);
+
+            vertices.extend(bitmap.vertices.iter().map(|v| GlyphVertex {
+                position: v.position * scale + offset,
+                tex_coords: v.tex_coords,
+                color,
+            }));
+
+            indices.extend_from_slice(&[
+                index,
+                index + 1,
+                index + 2,
+                index + 2,
+                index + 1,
+                index + 3,
+            ]);
+        }
+
+        self.fonts
+            .as_ref()
+            .zip(touched)
+            .for_each(|(font, touched)| {
+                font.touch(&touched);
+            });
+
+        state
+            .glyph_meshes
+            .as_mut()
+            .zip(glyph_meshes)
+            .for_each(|(mesh, (vertices, indices))| {
+                mesh.update(&state.device, &vertices, &indices)
+            });
+
+        state
+            .bg_mesh
+            .update(&state.device, &self.bg_vertices, &self.bg_indices);
+
+        state
+            .overlay_mesh
+            .update(&state.device, &self.overlay_vertices, &self.overlay_indices);
+    }
+
+    pub fn draw_cell(&mut self, cell: Indexed<&Cell>) {
+        if cell.flags.contains(Flags::HIDDEN) {
+            return;
+        }
+
+        let col = cell.point.column.0 as i32;
+        let row = cell.point.line.0;
+        let pos = self.grid_to_pos(col, row);
+        let mut fg = cell.fg;
+        let mut bg = cell.bg;
+
+        let is_full_block = cell.c == '▀';
+
+        if cell.flags.contains(Flags::INVERSE) ^ is_full_block {
+            std::mem::swap(&mut fg, &mut bg);
+        }
+
+        if !is_full_block {
+            let style = FontStyle::from_cell_flags(cell.flags);
+            let face = self.fonts.get(style).face.as_face_ref();
+            if let Some(glyph) = face.glyph_index(cell.c) {
+                let fg = self.color_to_u32(fg);
+                self.glyphs.push((pos, style, glyph.0, fg));
+            }
+        }
+
+        /*if bg == Color::Named(NamedColor::Background) {
+            return;
+        }*/
+
+        let bg = self.color_to_u32(bg);
+        let tl = self.grid_to_pos(col, row - 1);
+        let br = self.grid_to_pos(col + 1, row);
+        self.draw_solid_rect(tl, br, bg);
+    }
+
+    pub fn draw_cursor(&mut self, cursor: RenderableCursor) {
+        let cursor_color = Color::Named(NamedColor::Foreground);
+        let cursor_color = self.color_to_u32(cursor_color);
+        let col = cursor.point.column.0 as i32;
+        let row = cursor.point.line.0;
+        match cursor.shape {
+            CursorShape::Hidden => {}
+            _ => {
+                let tl = self.grid_to_pos(col, row - 1);
+                let br = self.grid_to_pos(col + 1, row);
+                self.draw_solid_rect(tl, br, cursor_color);
+            }
+        }
+    }
+
+    pub fn draw_solid_rect(&mut self, tl: Vec2, br: Vec2, color: u32) {
+        let index = self.bg_vertices.len() as u32;
+        self.bg_vertices.extend_from_slice(&[
+            SolidVertex {
+                position: tl,
+                color,
+            },
+            SolidVertex {
+                position: Vec2::new(br.x, tl.y),
+                color,
+            },
+            SolidVertex {
+                position: Vec2::new(tl.x, br.y),
+                color,
+            },
+            SolidVertex {
+                position: br,
+                color,
+            },
+        ]);
+
+        self.bg_indices.extend_from_slice(&[
+            index,
+            index + 1,
+            index + 2,
+            index + 2,
+            index + 1,
+            index + 3,
+        ]);
+    }
+
+    pub fn grid_to_pos(&self, x: i32, y: i32) -> Vec2 {
+        let col = x as f32 / 50.0 - 1.0;
+        let row = (y as f32 + 1.0) / -37.5 + 1.0;
+        Vec2::new(col, row)
+    }
+
+    pub fn color_to_rgb(&self, color: Color) -> Rgb {
+        match color {
+            Color::Named(name) => self.colors[name].unwrap(),
+            Color::Spec(rgb) => rgb,
+            Color::Indexed(index) => {
+                if let Some(color) = self.colors[index as usize] {
+                    color
+                } else if let Some(gray) = index.checked_sub(232) {
+                    let value = gray * 10 + 8;
+                    Rgb {
+                        r: value,
+                        g: value,
+                        b: value,
+                    }
+                } else if let Some(cube_idx) = index.checked_sub(16) {
+                    let r = cube_idx / 36;
+                    let g = (cube_idx / 6) % 6;
+                    let b = cube_idx % 6;
+
+                    let c = |c| {
+                        if c == 0 {
+                            0
+                        } else {
+                            c * 40 + 55
+                        }
+                    };
+
+                    Rgb {
+                        r: c(r),
+                        g: c(g),
+                        b: c(b),
+                    }
+                } else {
+                    Rgb {
+                        r: 0xff,
+                        g: 0x00,
+                        b: 0xff,
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn color_to_u32(&self, color: Color) -> u32 {
+        let rgb = self.color_to_rgb(color);
+        0xff000000 | ((rgb.b as u32) << 16) | ((rgb.g as u32) << 8) | (rgb.r as u32)
+    }
+}

--- a/crates/rend3-alacritty/src/terminal.rs
+++ b/crates/rend3-alacritty/src/terminal.rs
@@ -37,7 +37,7 @@ use alacritty_terminal::{
     tty::Pty,
     Term,
 };
-use glam::{IVec2, Quat, UVec2, Vec2, Vec3};
+use glam::{IVec2, Mat4, Quat, UVec2, Vec2, Vec3};
 use mio_extras::channel::Sender as MioSender;
 use owned_ttf_parser::AsFaceRef;
 use wgpu::{
@@ -287,6 +287,7 @@ impl Terminal {
 /// A ready-to-render terminal state.
 pub struct TerminalDrawState {
     pub device: Arc<Device>,
+    pub model: Mat4,
     pub camera_buffer: Buffer,
     pub camera_bind_group: BindGroup,
     pub bg_mesh: DynamicMesh<SolidVertex>,
@@ -313,6 +314,7 @@ impl TerminalDrawState {
         });
 
         Self {
+            model: Mat4::IDENTITY,
             camera_buffer,
             camera_bind_group,
             bg_mesh: DynamicMesh::new(&device),
@@ -440,6 +442,9 @@ impl TerminalCanvas {
         state
             .overlay_mesh
             .update(&state.device, &self.overlay_vertices, &self.overlay_indices);
+
+        state.model =
+            Mat4::from_translation(self.state.position) * Mat4::from_quat(self.state.orientation);
     }
 
     pub fn draw_cell(&mut self, cell: Indexed<&Cell>) {

--- a/crates/rend3-alacritty/src/terminal.rs
+++ b/crates/rend3-alacritty/src/terminal.rs
@@ -79,6 +79,7 @@ pub struct TerminalState {
     pub position: Vec3,
     pub orientation: Quat,
     pub half_size: Vec2,
+    pub opacity: f32,
 }
 
 /// Private terminal mutable state.
@@ -467,11 +468,14 @@ impl TerminalCanvas {
             }
         }
 
-        /*if bg == Color::Named(NamedColor::Background) {
-            return;
-        }*/
+        let bg = if bg == Color::Named(NamedColor::Background) {
+            let base = self.color_to_u32(bg);
+            let alpha = (self.state.opacity * 255.0) as u8;
+            ((alpha as u32) << 24) | (base & 0x00ffffff)
+        } else {
+            self.color_to_u32(bg)
+        };
 
-        let bg = self.color_to_u32(bg);
         let tl = self.grid_to_pos(col, row);
         let br = self.grid_to_pos(col + 1, row + 1);
         self.draw_solid_rect(tl, br, bg);

--- a/crates/rend3-alacritty/src/text.rs
+++ b/crates/rend3-alacritty/src/text.rs
@@ -1,0 +1,199 @@
+// Copyright (c) 2023 the Hearth contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
+
+use alacritty_terminal::term::cell::Flags;
+use font_mud::glyph_atlas::GlyphAtlas;
+use owned_ttf_parser::{AsFaceRef, OwnedFace};
+use wgpu::{util::DeviceExt, *};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FontStyle {
+    Regular,
+    Italic,
+    Bold,
+    BoldItalic,
+}
+
+impl FontStyle {
+    pub fn from_cell_flags(flags: Flags) -> Self {
+        if flags.contains(Flags::BOLD_ITALIC) {
+            Self::BoldItalic
+        } else if flags.contains(Flags::ITALIC) {
+            Self::Italic
+        } else if flags.contains(Flags::BOLD) {
+            Self::Bold
+        } else {
+            Self::Regular
+        }
+    }
+}
+
+/// Generic container for all font faces used in a terminal. Eases
+/// the writing of code manipulating all faces at once.
+#[derive(Clone, Debug, Default)]
+pub struct FontSet<T> {
+    pub regular: T,
+    pub italic: T,
+    pub bold: T,
+    pub bold_italic: T,
+}
+
+impl<T> FontSet<T> {
+    pub fn map<O>(self, f: impl Fn(T) -> O) -> FontSet<O> {
+        FontSet {
+            regular: f(self.regular),
+            italic: f(self.italic),
+            bold: f(self.bold),
+            bold_italic: f(self.bold_italic),
+        }
+    }
+
+    pub fn for_each(self, mut f: impl FnMut(T)) {
+        f(self.regular);
+        f(self.italic);
+        f(self.bold);
+        f(self.bold_italic);
+    }
+
+    pub fn get(&self, style: FontStyle) -> &T {
+        match style {
+            FontStyle::Regular => &self.regular,
+            FontStyle::Italic => &self.italic,
+            FontStyle::Bold => &self.bold,
+            FontStyle::BoldItalic => &self.bold_italic,
+        }
+    }
+
+    pub fn get_mut(&mut self, style: FontStyle) -> &mut T {
+        match style {
+            FontStyle::Regular => &mut self.regular,
+            FontStyle::Italic => &mut self.italic,
+            FontStyle::Bold => &mut self.bold,
+            FontStyle::BoldItalic => &mut self.bold_italic,
+        }
+    }
+
+    pub fn zip<O>(self, other: FontSet<O>) -> FontSet<(T, O)> {
+        FontSet {
+            regular: (self.regular, other.regular),
+            italic: (self.italic, other.italic),
+            bold: (self.bold, other.bold),
+            bold_italic: (self.bold_italic, other.bold_italic),
+        }
+    }
+
+    pub fn as_ref(&self) -> FontSet<&T> {
+        FontSet {
+            regular: &self.regular,
+            italic: &self.italic,
+            bold: &self.bold,
+            bold_italic: &self.bold_italic,
+        }
+    }
+
+    pub fn as_mut(&mut self) -> FontSet<&mut T> {
+        FontSet {
+            regular: &mut self.regular,
+            italic: &mut self.italic,
+            bold: &mut self.bold,
+            bold_italic: &mut self.bold_italic,
+        }
+    }
+}
+
+/// A font face and its MSDF glyph atlas.
+pub struct FaceAtlas {
+    pub face: OwnedFace,
+    pub atlas: GlyphAtlas,
+    pub texture: Texture,
+    pub queue: Arc<Queue>,
+    pub touched: Mutex<HashSet<u16>>,
+}
+
+impl FaceAtlas {
+    /// Create a new atlas from a face. Note that this takes time to complete.
+    pub fn new(face: OwnedFace, device: &Device, queue: Arc<Queue>) -> Self {
+        let (atlas, _errors) = GlyphAtlas::new(face.as_face_ref()).unwrap();
+
+        let size = Extent3d {
+            width: atlas.width,
+            height: atlas.height,
+            depth_or_array_layers: 1,
+        };
+
+        let texture = device.create_texture_with_data(
+            &queue,
+            &TextureDescriptor {
+                label: Some("AlacrittyRoutine::glyph_texture"),
+                size,
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: TextureDimension::D2,
+                format: TextureFormat::Rgba8Unorm,
+                usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
+            },
+            &vec![0u8; (atlas.width * atlas.height * 4) as usize],
+        );
+
+        Self {
+            face,
+            atlas,
+            texture,
+            queue,
+            touched: Default::default(),
+        }
+    }
+
+    /// Generate and upload a glyph bitmap for each glyph that hasn't already been.
+    pub fn touch(&self, glyphs: &[u16]) {
+        let mut touched = self.touched.lock().unwrap();
+        for glyph in glyphs {
+            if touched.insert(*glyph) {
+                let glyph = self.atlas.glyphs.get(*glyph as usize);
+                let Some(Some(glyph)) = glyph else { continue };
+                let bitmap = glyph.shape.generate();
+
+                self.queue.write_texture(
+                    ImageCopyTexture {
+                        texture: &self.texture,
+                        mip_level: 0,
+                        origin: Origin3d {
+                            x: glyph.position.x,
+                            y: glyph.position.y,
+                            z: 0,
+                        },
+                        aspect: TextureAspect::All,
+                    },
+                    bitmap.data_bytes(),
+                    ImageDataLayout {
+                        offset: 0,
+                        bytes_per_row: std::num::NonZeroU32::new(glyph.size.x * 4),
+                        rows_per_image: std::num::NonZeroU32::new(glyph.size.y),
+                    },
+                    Extent3d {
+                        width: glyph.size.x,
+                        height: glyph.size.y,
+                        depth_or_array_layers: 1,
+                    },
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Big refactors and improvements to `rend3-alacritty`.

- better color usage
- abstract and organize terminal management
- orbit controls in demo (closes #37)
- font-based cell metrics
- support state + resizing
- background opacity
- transform terminals with state
- dynamic terminal colors
- configure the shell to run with platform-specific autoselect as fallback