### PR TITLE
alacritty: setup env vars

### DIFF
--- a/crates/rend3-alacritty/src/terminal.rs
+++ b/crates/rend3-alacritty/src/terminal.rs
@@ -291,6 +291,9 @@ impl Terminal {
             ..Default::default()
         };
 
+        // setup environment variables
+        alacritty_terminal::tty::setup_env(&term_config);
+
         let term_listener = Listener::new(sender.clone());
 
         let term = Term::new(&term_config, size_info, term_listener);


### PR DESCRIPTION
Closes #173.

I'll follow this up with an issue to manage the distribution of Alacritty terminfo like discussed, but the `setup_env` function falls back to `xterm-256color` if it can't find Alacritty's, so I think that we're ok to use this in main for now.