### PR TITLE
ipc: enable tokio sync feature

### DIFF
--- a/crates/hearth-ipc/Cargo.toml
+++ b/crates/hearth-ipc/Cargo.toml
@@ -7,5 +7,5 @@ license = "AGPL-3.0-or-later"
 [dependencies]
 bincode = "1.3"
 hearth-types = { workspace = true }
-tokio = { version = "1.24", features = ["io-util", "net"] }
+tokio = { version = "1.24", features = ["io-util", "net", "sync"] }
 tracing = { workspace = true }


### PR DESCRIPTION
Fixes a local build failure where `hearth-ipc` was failing to import `tokio::sync` since the "sync" feature on Tokio wasn't enabled.

Not sure why this wasn't an issue in CI before, but I figure that it's because I updated my Rust version and that somehow affects feature directives in dependencies. Best to get this patched upstream ASAP.
