### PR TITLE
ctl: remove yacexits dep

### DIFF
--- a/crates/hearth-ctl/Cargo.toml
+++ b/crates/hearth-ctl/Cargo.toml
@@ -10,4 +10,3 @@ hearth-ipc = { workspace = true }
 hearth-types = { workspace = true }
 serde_json = { workspace = true }
 tokio = { version = "1.24", features = ["macros", "net", "rt", "signal"] }
-yacexits = "0.1"


### PR DESCRIPTION
yacexits requires a clang system dependency to compile on at least Mac, so we're going to substitute it for something else. I'm removing it for now until we can decide what the new best way to return standard error codes is.
