### PR TITLE
Fix init

### DIFF
--- a/crates/hearth-init/src/lib.rs
+++ b/crates/hearth-init/src/lib.rs
@@ -101,7 +101,11 @@ impl Plugin for InitPlugin {
                 let response_cap = response.export(Permissions::SEND, table).unwrap();
 
                 let perms = Permissions::SEND | Permissions::MONITOR;
-                let registry = parent.borrow_parent().export(perms, table).unwrap();
+                let registry = runtime
+                    .registry
+                    .borrow_parent()
+                    .export(perms, table)
+                    .unwrap();
 
                 let request = RegistryRequest::Get {
                     name: "hearth.cognito.WasmProcessSpawner".to_string(),

--- a/guest/rust/hearth-guest/src/lib.rs
+++ b/guest/rust/hearth-guest/src/lib.rs
@@ -117,7 +117,7 @@ pub static REGISTRY: Registry = RequestResponse::new(Capability(0));
 lazy_static::lazy_static! {
     /// A lazily-initialized handle to the WebAssembly spawner service.
     pub static ref WASM_SPAWNER: RequestResponse<wasm::WasmSpawnInfo, ()> = {
-        RequestResponse::new(REGISTRY.get_service("hearth.cognito.WasmCapabilitySpawner").unwrap())
+        RequestResponse::new(REGISTRY.get_service("hearth.cognito.WasmProcessSpawner").unwrap())
     };
 }
 


### PR DESCRIPTION
Fixes a logic issue that kept the init system from starting at all. Also corrects a typo in the Wasm process spawner name.