### PR TITLE
client: switch from Immediate to Fifo present mode

### DIFF
--- a/crates/hearth-client/src/window.rs
+++ b/crates/hearth-client/src/window.rs
@@ -80,7 +80,7 @@ impl Window {
             format: swapchain_format,
             width: size.width,
             height: size.height,
-            present_mode: wgpu::PresentMode::Immediate,
+            present_mode: wgpu::PresentMode::Fifo,
         };
 
         surface.configure(&iad.device, &config);


### PR DESCRIPTION
Fixes some flickering I was experiencing while running multiple terminal emulators.
