### PR TITLE
github: update depgraph on main push only

### DIFF
--- a/.github/workflows/depgraph.yml
+++ b/.github/workflows/depgraph.yml
@@ -5,9 +5,6 @@ on:
   push:
     paths: [ "**/Cargo.toml" ]
     branches: [ "main" ]
-  pull_request:
-    paths: [ "**/Cargo.toml" ]
-    branches: [ "main" ]
 
 permissions:
   contents: write


### PR DESCRIPTION
Running the depgraph update workflow in PRs is causing merge conflicts and invalidating CI passes, making it difficult to get PRs that update the depgraph merged. Since the depgraph visualization only needs to be updated on the main branch, we've decided to disable it for PRs.
