### PR TITLE
github: always trigger PR CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,16 +3,8 @@ name: Pull Request Checks
 on:
   push:
     branches: [ "main" ]
-    paths:
-      - "**/Cargo.toml"
-      - "**.rs"
-      - ".github/**"
   pull_request:
     branches: [ "main" ]
-    paths:
-      - "**/Cargo.toml"
-      - "**.rs"
-      - ".github/**"
 
 jobs:
   build:


### PR DESCRIPTION
Hopefully makes it less of a pain to track whether commits pass CI or not by ALWAYS running CI regardless of which files are changed.