### PR TITLE
terminal: don't skip drawing foregrounds of 'full' cells

### DIFF
--- a/plugins/terminal/src/terminal.rs
+++ b/plugins/terminal/src/terminal.rs
@@ -490,9 +490,7 @@ impl TerminalCanvas {
         let mut fg = cell.fg;
         let mut bg = cell.bg;
 
-        let is_full_block = cell.c == '▀';
-
-        if cell.flags.contains(Flags::INVERSE) ^ is_full_block {
+        if cell.flags.contains(Flags::INVERSE) {
             std::mem::swap(&mut fg, &mut bg);
         }
 
@@ -506,11 +504,6 @@ impl TerminalCanvas {
         };
 
         self.draw_solid_rect(tl, br, bg);
-
-        // skip foreground rendering if the entire cell is occupied
-        if is_full_block {
-            return;
-        }
 
         let style = FontStyle::from_cell_flags(cell.flags);
         let font = self.fonts.get(style);


### PR DESCRIPTION
Before:
![20240111_15h45m48s_grim](https://github.com/hearth-rs/hearth/assets/56894066/3c273fbc-ced3-4eb2-a3f8-2bd94cdd194c)

After:
![20240111_15h47m58s_grim](https://github.com/hearth-rs/hearth/assets/56894066/a1210ac4-ab1f-4e11-a8a7-68ca0319a3a6)

I'm not sure there was ever a full cell Unicode character to begin with.