### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+indent_size = 4
+insert_final_newline = true


### PR DESCRIPTION
My neovim configuration has 2-character-wide tabs by default so in order to get the rustfmt-approved™ experience with hearth contribution, having .editorconfig is useful :)