### PR TITLE
terminal: ceil->floor available panel size

### DIFF
--- a/plugins/terminal/src/terminal.rs
+++ b/plugins/terminal/src/terminal.rs
@@ -174,7 +174,7 @@ impl Terminal {
 
         let available = (initial_state.half_size - initial_state.padding) * 2.0;
         let grid_size = (available / cell_size / initial_state.units_per_em)
-            .ceil()
+            .floor()
             .as_uvec2();
 
         let size_info = alacritty_terminal::term::SizeInfo::new(
@@ -253,7 +253,7 @@ impl Terminal {
 
         let available = (state.half_size - state.padding) * 2.0;
         let grid_size = (available / self.cell_size / state.units_per_em)
-            .ceil()
+            .floor()
             .as_uvec2();
 
         if inner.grid_size != grid_size {


### PR DESCRIPTION
Fixes a graphical bug in terminal rendering where the terminal would size the grid to exceed the available panel size if the padding is low, leading to the padding being drawn on top of the grid.

Before:
![20240131_12h01m57s_grim](https://github.com/hearth-rs/hearth/assets/56894066/dda0068a-4e17-45bc-a857-14e277130dd8)

After:
![20240131_12h10m56s_grim](https://github.com/hearth-rs/hearth/assets/56894066/c7c91173-b823-4da1-beb6-d63051431e4c)
